### PR TITLE
ci: trigger release workflow on main pushes with guarded publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
@@ -9,8 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  publish-crates:
-    name: Publish to Crates.io
+  release-readiness:
+    name: Release Readiness Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -20,6 +22,14 @@ jobs:
           components: rustfmt, clippy
       - name: Run checks
         run: scripts/check.sh
+
+  publish-crates:
+    name: Publish to Crates.io
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: release-readiness
+    steps:
+      - uses: actions/checkout@v6
       - name: Publish biors-core
         run: cargo publish -p biors-core --token ${{ secrets.CRATES_IO_TOKEN }}
       - name: Publish biors


### PR DESCRIPTION
### Motivation
- Ensure the release workflow runs on `main` pushes so release-related metadata and readiness checks run when main is updated.
- Always run the Rust verification steps for any release workflow invocation to catch issues early.
- Prevent accidental crate publication by restricting actual `cargo publish` to version tag pushes only.

### Description
- Updated `.github/workflows/release.yml` to add a `push.branches: [main]` trigger alongside the existing `tags: ['v*']` trigger.
- Added a `release-readiness` job that performs `actions/checkout@v6`, installs the Rust toolchain via `dtolnay/rust-toolchain@stable` (with `rustfmt` and `clippy`), and runs `scripts/check.sh`.
- Made the `publish-crates` job depend on `release-readiness` and added `if: startsWith(github.ref, 'refs/tags/v')` so that `cargo publish` only runs for tag pushes.

### Testing
- Ran `scripts/check.sh`, which executed `cargo fmt --check`, `cargo check` (including wasm target), `cargo test` and `cargo clippy`, and the script completed successfully.
- All unit and integration tests run by `scripts/check.sh` passed in the environment where the change was validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9ea345e0833293144f34bab83d23)