### PR TITLE
docs: add growth entry points

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark_performance_idea.md
+++ b/.github/ISSUE_TEMPLATE/benchmark_performance_idea.md
@@ -1,0 +1,28 @@
+---
+name: Benchmark or performance idea
+about: Suggest a reproducible benchmark, dataset, or performance comparison
+title: "benchmark: "
+labels: benchmark
+assignees: ""
+---
+
+## What should be measured?
+
+
+## Why does this benchmark matter?
+
+
+## Dataset or input
+
+- Source:
+- Size:
+- License or access notes:
+
+## Baseline to compare against
+
+
+## Completion criteria
+
+- [ ] Benchmark input is documented
+- [ ] Command is reproducible
+- [ ] Result is recorded without overclaiming

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report behavior that is broken or surprising
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## What happened?
+
+
+## Expected behavior
+
+
+## Minimal reproduction
+
+Command:
+
+```bash
+
+```
+
+Input file or snippet:
+
+```txt
+
+```
+
+## Environment
+
+- OS:
+- Rust version (`rustc --version`):
+- Cargo version (`cargo --version`):
+- bio-rs version or commit:
+
+## Output
+
+```txt
+
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: bio-rs roadmap
+    url: https://github.com/bio-rs/bio-rs
+    about: Check the README for current capabilities and roadmap boundaries before opening broad roadmap requests.

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.md
@@ -1,0 +1,23 @@
+---
+name: Documentation improvement
+about: Improve README, examples, comments, or contributor docs
+title: "docs: "
+labels: documentation
+assignees: ""
+---
+
+## What is unclear?
+
+
+## Where is it?
+
+- File or URL:
+- Section:
+
+## Suggested improvement
+
+
+## Completion criteria
+
+- [ ] The updated text matches current implemented behavior
+- [ ] Roadmap or not-yet-implemented claims are clearly marked

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature request
+about: Propose a small, concrete bio-rs capability
+title: "feature: "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+
+## Proposed behavior
+
+
+## Example input/output
+
+Input:
+
+```txt
+
+```
+
+Expected output:
+
+```json
+
+```
+
+## Scope notes
+
+- Is this a CLI behavior change?
+- Is this a Rust public API change?
+- Does this change JSON output?
+- Does this require a new dependency?
+
+## Completion criteria
+
+

--- a/.github/ISSUE_TEMPLATE/question_use_case.md
+++ b/.github/ISSUE_TEMPLATE/question_use_case.md
@@ -1,0 +1,20 @@
+---
+name: Question or use case
+about: Ask whether bio-rs fits a workflow or share a use case
+title: "question: "
+labels: question
+assignees: ""
+---
+
+## What are you trying to do?
+
+
+## Current workflow
+
+
+## Where could bio-rs fit?
+
+
+## Useful input/output examples
+
+

--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+One or two sentences describing what this release makes possible.
+
+## Changes
+
+- 
+
+## Current capabilities
+
+- 
+
+## Documentation
+
+- README updated:
+- CONTRIBUTING updated:
+- Examples or fixtures updated:
+
+## Verification
+
+- `scripts/check.sh`:
+- Release workflow:
+- Crates.io:
+
+## Closed issues
+
+- 
+
+## Next
+
+One sentence describing the next release target without presenting roadmap work
+as current behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,26 @@ cargo build
 3. Add/update tests with behavior changes.
 4. Run the full check script before pushing.
 
+## Choosing an issue
+
+If this is your first contribution, start with issues labeled
+`good first issue`. These should be small enough to finish without knowing the
+whole project.
+
+Issues labeled `help wanted` are also open to contributors, but they may need
+more discussion or domain context first.
+
+Good first contributions include:
+
+- README or example wording that makes current behavior clearer
+- Quickstart verification on a fresh checkout
+- small FASTA fixture additions
+- clearer error messages for existing validation paths
+- documentation fixes that separate current behavior from roadmap ideas
+
+Documentation contributions are welcome. If a doc change updates public
+behavior, include the command, input, output, or API surface it describes.
+
 ## Commands
 
 Run the repository check suite:
@@ -83,3 +103,9 @@ Please include:
 - minimal reproduction input
 - expected vs actual behavior
 - CLI output or stack traces
+
+## Asking questions or sharing use cases
+
+Use the question / use case issue template when you are not sure whether a
+workflow belongs in bio-rs yet. Small, concrete examples are more useful than
+broad roadmap requests.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Use this crate when you need shell-first workflows, scripting, or CI checks.
 
 `0.7.0` capability notes are kept only as release history above; all "current" descriptions in this README are aligned to **0.8.1**.
 
+### Not yet
+
+These are roadmap directions, not current capabilities:
+
+- hosted web workflows
+- Python bindings
+- model inference backends
+- package registry or plugin ecosystem
+- general-purpose chemistry or structure tooling
+
 ## Quickstart
 
 Inspect FASTA records:
@@ -107,6 +117,49 @@ cargo run -p biors -- package verify \
   examples/protein-package/manifest.json \
   examples/protein-package/observations.json
 ```
+
+## Proof asset
+
+This is the smallest reproducible package verification example in the repository.
+
+Command:
+
+```bash
+cargo run -p biors -- package verify \
+  examples/protein-package/manifest.json \
+  examples/protein-package/observations.json
+```
+
+Input:
+
+- package manifest: `examples/protein-package/manifest.json`
+- observed fixture map: `examples/protein-package/observations.json`
+- expected output fixture: `examples/protein-package/fixtures/tiny.output.json`
+
+Output shape:
+
+```json
+{
+  "package": "protein-seed",
+  "fixtures": 1,
+  "passed": 1,
+  "failed": 0,
+  "results": [
+    {
+      "name": "tiny-protein",
+      "input": "fixtures/tiny.fasta",
+      "expected_output": "fixtures/tiny.output.json",
+      "observed_output": "fixtures/tiny.output.json",
+      "status": "passed",
+      "issue": null
+    }
+  ]
+}
+```
+
+This proves that a portable package manifest can point to fixture inputs and
+expected JSON outputs, and that `biors` can check observed outputs against that
+contract. It is a small contract test, not a model inference benchmark.
 
 ## Evidence and benchmarks
 


### PR DESCRIPTION
## Summary

Adds GitHub growth entry points from the roadmap without including the in-progress 0.9 work.

## Changes

- Add issue templates for bugs, docs, features, benchmarks, and questions/use cases
- Add a release note template
- Add README Not Yet boundaries and a package verify proof asset
- Expand CONTRIBUTING with issue selection and first contribution guidance

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `scripts/check.sh`