### PR TITLE
fix: publish core before CLI release dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Dry-run publish biors-core
         run: cargo publish --locked -p biors-core --dry-run
-      - name: Dry-run publish biors
-        run: cargo publish --locked -p biors --dry-run
       - name: Publish biors-core
         run: cargo publish --locked -p biors-core --token ${{ secrets.CRATES_IO_TOKEN }}
       - name: Wait for biors-core index
@@ -60,6 +58,8 @@ jobs:
 
           echo "biors-core $version did not appear in crates index in time" >&2
           exit 1
+      - name: Dry-run publish biors
+        run: cargo publish --locked -p biors --dry-run
       - name: Publish biors
         run: cargo publish --locked -p biors --token ${{ secrets.CRATES_IO_TOKEN }}
 

--- a/scripts/check-fast.sh
+++ b/scripts/check-fast.sh
@@ -17,10 +17,14 @@ echo "==> python syntax"
 python3 -m py_compile \
   scripts/benchmark_fasta_vs_biopython.py \
   scripts/check-benchmark-artifact.py \
+  scripts/check-release-workflow.py \
   scripts/render_benchmark_report.py
 
 echo "==> benchmark docs"
 scripts/check-benchmark-docs.sh
+
+echo "==> release workflow"
+python3 scripts/check-release-workflow.py
 
 echo "==> cargo fmt --check"
 cargo fmt --all --check

--- a/scripts/check-release-workflow.py
+++ b/scripts/check-release-workflow.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Validate release workflow invariants that affect crates.io publication."""
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/release.yml")
+
+
+def main() -> None:
+    lines = WORKFLOW.read_text(encoding="utf-8").splitlines()
+
+    required_order = [
+        "- name: Dry-run publish biors-core",
+        "- name: Publish biors-core",
+        "- name: Wait for biors-core index",
+        "- name: Dry-run publish biors",
+        "- name: Publish biors",
+    ]
+
+    positions: list[tuple[str, int]] = []
+    for marker in required_order:
+        matching_lines = [
+            line_number
+            for line_number, line in enumerate(lines, start=1)
+            if line.strip() == marker
+        ]
+        if not matching_lines:
+            raise SystemExit(f"release workflow is missing step: {marker}")
+        positions.append((marker, matching_lines[0]))
+
+    out_of_order = [
+        (previous, current)
+        for (previous, previous_position), (current, current_position) in zip(
+            positions, positions[1:]
+        )
+        if previous_position >= current_position
+    ]
+    if out_of_order:
+        details = "; ".join(
+            f"{previous} must appear before {current}"
+            for previous, current in out_of_order
+        )
+        raise SystemExit(f"release workflow publish order is unsafe: {details}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -20,10 +20,14 @@ echo "==> python syntax"
 python3 -m py_compile \
   scripts/benchmark_fasta_vs_biopython.py \
   scripts/check-benchmark-artifact.py \
+  scripts/check-release-workflow.py \
   scripts/render_benchmark_report.py
 
 echo "==> benchmark docs"
 scripts/check-benchmark-docs.sh
+
+echo "==> release workflow"
+python3 scripts/check-release-workflow.py
 
 echo "==> cargo check --workspace --all-targets --all-features"
 cargo check --locked --workspace --all-targets --all-features


### PR DESCRIPTION
## Summary
- move the `biors` publish dry-run until after `biors-core` has been published and observed in the crates.io index
- add a release workflow invariant check so this ordering regression is caught by `scripts/check-fast.sh` and `scripts/check.sh`

## Verification
- python3 scripts/check-release-workflow.py (red before workflow reorder, green after)
- scripts/check-fast.sh
- scripts/check.sh

## Release context
- fixes the workflow issue that blocked the `v0.11.0` tag workflow at the `biors` dry-run step
- needed before pushing `v0.12.0` so the tag workflow can publish `biors-core` before validating and publishing `biors`
