### PR TITLE
chore: prepare bio-rs 0.12.1 readiness patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable pre-1.0 changes are summarized here. GitHub Releases remain the
 source for exact commit lists after tags are published.
 
+## 0.12.1
+
+- Added a release workflow invariant check and fixed crates.io publish ordering
+  so `biors-core` is published before `biors` dry-run validation.
+- Added a professional-readiness audit document covering Phase 1 and Phase 2
+  implementation status, researcher-ready scope, and known limits.
+- Switched `biors inspect` to a summary-only FASTA reader path to avoid
+  materializing token vectors for large-input summaries.
+- Updated quickstart documentation for the published CLI install path.
+
 ## 0.12.0
 
 - Added full CLI workflow coverage for FASTA validation, tokenization,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "biors"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "biors-core",
  "clap",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "biors-core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bio-rs/bio-rs"
-version = "0.12.0"
+version = "0.12.1"
 
 [workspace.dependencies]
-biors-core = { version = "0.12.0", path = "packages/rust/biors-core" }
+biors-core = { version = "0.12.1", path = "packages/rust/biors-core" }
 clap = { version = "4.5.37", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -38,28 +38,34 @@ The goal is to make the input layer around bio-AI models faster, more portable, 
 
 ## Quickstart
 
+Install the published CLI:
+
+```bash
+cargo install biors --version 0.12.1
+```
+
 Tokenize a FASTA file:
 
 ```bash
-cargo run -p biors -- tokenize examples/protein.fasta
+biors tokenize examples/protein.fasta
 ```
 
 Pipe FASTA through stdin:
 
 ```bash
-printf '>tiny\nACDE\n' | cargo run -p biors -- tokenize -
+printf '>tiny\nACDE\n' | biors tokenize -
 ```
 
 Validate FASTA:
 
 ```bash
-cargo run -p biors -- fasta validate examples/protein.fasta
+biors fasta validate examples/protein.fasta
 ```
 
 Verify package fixture outputs:
 
 ```bash
-cargo run -p biors -- package verify \
+biors package verify \
   examples/protein-package/manifest.json \
   examples/protein-package/observations.json
 ```
@@ -67,7 +73,7 @@ cargo run -p biors -- package verify \
 Build model-ready input records:
 
 ```bash
-cargo run -p biors -- model-input --max-length 8 examples/protein.fasta
+biors model-input --max-length 8 examples/protein.fasta
 ```
 
 ## Proof
@@ -264,6 +270,7 @@ Tokenization output is record-oriented:
 Public contract docs:
 
 - [Quickstart](docs/quickstart.md)
+- [Professional readiness](docs/professional-readiness.md)
 - [CLI contract](docs/cli-contract.md)
 - [Error code registry](docs/error-codes.md)
 - [1.0 contract candidates](docs/public-contract-1.0-candidates.md)
@@ -279,6 +286,7 @@ Public contract docs:
 
 Delivered:
 
+- `0.12.1`: release workflow publish-order guard, published CLI quickstart, professional-readiness audit, and summary-only FASTA inspect path
 - `0.12.0`: release-candidate documentation, full workflow e2e coverage, MSRV/citation policy drafts, and changelog
 - `0.11.0`: benchmark reproducibility metadata, generated benchmark report checks, and refreshed speed/memory proof assets
 - `0.10.0`: fixture and verification hardening with shared byte-aware FASTA scanning, tokenizer invariants, and structured mismatch reports
@@ -331,6 +339,7 @@ The check suite runs:
 - `cargo fmt`
 - shell and Python syntax checks for repo scripts
 - benchmark Markdown regeneration check
+- release workflow publish-order invariant check
 - Rust checks
 - `biors-core` `wasm32-unknown-unknown` build check
 - tests

--- a/docs/api-review.md
+++ b/docs/api-review.md
@@ -1,6 +1,6 @@
 # API and Schema Review
 
-This document records the 0.12.0 review state for the 1.0 release-candidate
+This document records the 0.12.x review state for the 1.0 release-candidate
 path. It is not a promise that every listed surface is stable today.
 
 ## Rust API
@@ -12,6 +12,8 @@ Reviewed for 0.12.0:
 
 - FASTA parse and reader APIs keep line and record-index diagnostics.
 - Tokenization preserves sequence length with explicit unknown-token IDs.
+- FASTA inspect summaries can be produced from reader input without
+  materializing token vectors.
 - Model-input builders separate checked and unchecked paths.
 - Package verification reports include stable issue codes plus content diff
   metadata for mismatches.

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -18,6 +18,8 @@ It rejects sequences that still contain residue warnings or errors, so model-rea
 `--max-length` must be greater than zero.
 `tokenize` preserves positional alignment by emitting explicit unknown-token IDs for ambiguous or invalid residues instead of shortening the token vector.
 FASTA-backed CLI commands read through buffered reader APIs and compute the legacy `fnv1a64:` input hash during the same pass.
+`inspect` uses a summary-only reader path and does not materialize token vectors
+when it only needs record, residue, warning, and error counts.
 
 Manifest-relative paths are resolved against the manifest file's parent directory. If the manifest is read from stdin, relative paths are resolved against the current working directory.
 Absolute paths and `..` parent traversal are rejected so packages remain portable and self-contained.

--- a/docs/professional-readiness.md
+++ b/docs/professional-readiness.md
@@ -1,0 +1,66 @@
+# Professional Readiness
+
+This document records the current readiness boundary for using bio-rs in
+day-to-day biological sequence preprocessing workflows.
+
+## Researcher-Ready Scope
+
+bio-rs is ready for local and CI use when the workflow is:
+
+- protein FASTA parsing and normalization
+- protein-20 validation with explicit ambiguous-residue warnings
+- stable token ID generation with positional unknown-token preservation
+- deterministic model-input JSON for fixed-length or unpadded model inputs
+- package manifest inspection and portable asset validation
+- package fixture verification against observed output artifacts
+- reproducible FASTA validation/tokenization benchmarking
+
+The strongest fit today is preprocessing and verification around biological AI
+model inputs. The project should be presented as input-contract infrastructure,
+not as a model inference engine or broad bioinformatics suite.
+
+## Phase 1 Coverage
+
+| Version | Planned area | Current status |
+|---|---|---|
+| 0.1.0 | workspace, core/CLI split, FASTA skeleton, fixtures, CI, security policy | Implemented through the Rust workspace, `biors-core`, `biors`, test fixtures, CI, and `SECURITY.md`. |
+| 0.2.0 | FASTA parser MVP with headers, records, empty lines, CRLF, invalid errors, line/record diagnostics | Implemented and covered by parser contract tests and fixtures. |
+| 0.3.0 | protein validation, lowercase/whitespace normalization, ambiguous residue policy, validation report | Implemented in `sequence` and FASTA validation contracts. |
+| 0.4.0 | tokenizer trait, protein tokenizer, vocab loading, unknown-token policy, fixtures | Implemented in `tokenizer` with tokenizer golden fixtures. |
+| 0.5.0 | model-ready input, attention mask, padding/truncation, deterministic JSON schemas | Implemented with model-input builders, CLI output, and schema contract tests. |
+| 0.6.0 | CLI stabilization draft, JSON mode, exit codes, human errors, landing docs linkage | Implemented for repo-local CLI/docs; hosted website remains out of scope for this checkout. |
+| 0.7.0 | provenance metadata, input hash, version in output, verification harness, mismatch report | Implemented through success envelopes, input hashes, and package verification. |
+| 0.8.0 | package manifest draft, schema validation, checksums, runtime/input/output contract fields | Implemented with typed manifest enums, checksum validation, and package CLI commands. |
+
+## Phase 2 Coverage
+
+| Version | Planned area | Current status |
+|---|---|---|
+| 0.9.0 | CLI and JSON contract freeze, error taxonomy, snapshots, contract candidates | Implemented in CLI/schema/error docs and public behavior tests. |
+| 0.10.0 | fixture and verification hardening, invalid FASTA invariants, tokenizer invariants | Implemented with expanded fixtures, deterministic invalid FASTA tests, and structured mismatch reports. |
+| 0.11.0 | benchmark and reproducibility pass, Biopython comparison, speed/memory proof assets | Implemented with reproducible benchmark JSON/Markdown and artifact validation. |
+| 0.12.0 | documentation and 1.0 release candidate, full workflow e2e, policies, changelog | Implemented with e2e CLI workflow tests, quickstart, API/schema review, MSRV, citation, and changelog. |
+
+## Refactor And Performance Review
+
+- FASTA parsing now uses a shared scanner for string and reader paths, reducing
+  duplicated state-machine logic.
+- ASCII FASTA paths avoid Unicode scalar iteration where byte-level handling is
+  safe, while retaining Unicode fallback behavior for compatibility.
+- `biors inspect` uses a summary-only reader path so large FASTA inspection no
+  longer materializes token vectors just to count records, residues, warnings,
+  and errors.
+- Vocabulary token definitions are static; callers that need only the canonical
+  token list can use `protein_20_vocab_tokens()` without rebuilding a `Vec`.
+
+## Known Limits
+
+- Only protein FASTA and the `protein-20` tokenizer are supported.
+- Non-protein alphabets, nucleotide workflows, structure tooling, chemistry
+  tooling, and Python bindings are not implemented.
+- Package verification compares local artifacts; bio-rs does not run model
+  inference backends.
+- Benchmark claims are limited to the committed FASTA validation/tokenization
+  workloads and should not be generalized to every Biopython use case.
+- The project is still pre-1.0, so public contracts are stabilization
+  candidates rather than final stable guarantees.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,10 +3,19 @@
 This guide uses the repository examples so each command is reproducible from a
 fresh checkout.
 
+## Install
+
+```bash
+cargo install biors --version 0.12.1
+```
+
+When working inside a source checkout, replace `biors` with
+`cargo run -p biors --`.
+
 ## Validate FASTA
 
 ```bash
-cargo run -p biors -- fasta validate examples/protein.fasta
+biors fasta validate examples/protein.fasta
 ```
 
 Use this first when you need structured diagnostics for record counts,
@@ -15,7 +24,7 @@ ambiguous residues, and invalid residues.
 ## Tokenize FASTA
 
 ```bash
-cargo run -p biors -- tokenize examples/protein.fasta
+biors tokenize examples/protein.fasta
 ```
 
 `tokenize` emits stable `protein-20` token IDs. Ambiguous or invalid residues
@@ -24,7 +33,7 @@ keep positional alignment by using the explicit unknown token ID.
 ## Build Model Input
 
 ```bash
-cargo run -p biors -- model-input --max-length 8 examples/protein.fasta
+biors model-input --max-length 8 examples/protein.fasta
 ```
 
 `model-input` emits `input_ids`, `attention_mask`, and truncation metadata. It
@@ -33,8 +42,8 @@ rejects sequences with unresolved residue warnings or errors.
 ## Verify Package Fixtures
 
 ```bash
-cargo run -p biors -- package validate examples/protein-package/manifest.json
-cargo run -p biors -- package verify \
+biors package validate examples/protein-package/manifest.json
+biors package verify \
   examples/protein-package/manifest.json \
   examples/protein-package/observations.json
 ```

--- a/packages/rust/biors-core/src/lib.rs
+++ b/packages/rust/biors-core/src/lib.rs
@@ -33,10 +33,10 @@ pub use sequence::{
 };
 pub use tokenizer::{
     load_protein_20_vocab, load_vocab_json, protein_20_unknown_token_policy,
-    protein_20_vocab_tokens, summarize_tokenized_proteins, tokenize_fasta_records,
-    tokenize_fasta_records_reader, tokenize_protein, ProteinBatchSummary, ProteinTokenizer,
-    TokenizedFastaInput, TokenizedProtein, Tokenizer, UnknownTokenPolicy, VocabToken, Vocabulary,
-    PROTEIN_20_UNKNOWN_TOKEN_ID,
+    protein_20_vocab_tokens, summarize_fasta_records_reader, summarize_tokenized_proteins,
+    tokenize_fasta_records, tokenize_fasta_records_reader, tokenize_protein, ProteinBatchSummary,
+    ProteinTokenizer, SummarizedFastaInput, TokenizedFastaInput, TokenizedProtein, Tokenizer,
+    UnknownTokenPolicy, VocabToken, Vocabulary, PROTEIN_20_UNKNOWN_TOKEN_ID,
 };
 pub use verification::{
     stable_input_hash, verify_package_outputs, verify_package_outputs_with_observation_base,

--- a/packages/rust/biors-core/src/tokenizer.rs
+++ b/packages/rust/biors-core/src/tokenizer.rs
@@ -167,7 +167,7 @@ pub struct TokenizedProtein {
     pub errors: Vec<ResidueIssue>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProteinBatchSummary {
     pub records: usize,
     pub total_length: usize,
@@ -180,6 +180,12 @@ pub struct ProteinBatchSummary {
 pub struct TokenizedFastaInput {
     pub input_hash: String,
     pub records: Vec<TokenizedProtein>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SummarizedFastaInput {
+    pub input_hash: String,
+    pub summary: ProteinBatchSummary,
 }
 
 pub fn tokenize_fasta_records(input: &str) -> Result<Vec<TokenizedProtein>, BioRsError> {
@@ -201,6 +207,18 @@ pub fn tokenize_fasta_records_reader<R: BufRead>(
             .into_iter()
             .map(|record| record.tokenized)
             .collect(),
+    })
+}
+
+pub fn summarize_fasta_records_reader<R: BufRead>(
+    reader: R,
+) -> Result<SummarizedFastaInput, crate::FastaReadError> {
+    let mut sink = SummaryRecordSink::default();
+    let input_hash = scan_fasta_reader(reader, &mut sink)?;
+
+    Ok(SummarizedFastaInput {
+        input_hash,
+        summary: sink.summary,
     })
 }
 
@@ -441,6 +459,89 @@ impl FastaRecordSink for AnalyzedRecordSink {
         };
         self.records.push(AnalyzedProtein { protein, tokenized });
         Ok(())
+    }
+}
+
+#[derive(Default)]
+struct SummaryRecordSink {
+    summary: ProteinBatchSummary,
+    current_length: usize,
+    current_warning_count: usize,
+    current_error_count: usize,
+}
+
+impl FastaRecordSink for SummaryRecordSink {
+    fn push_sequence_line(&mut self, line: &str) {
+        if line.is_ascii() {
+            for byte in line.bytes() {
+                if byte.is_ascii_whitespace() {
+                    continue;
+                }
+                self.push_residue_byte(byte);
+            }
+            return;
+        }
+
+        for residue in normalized_residues(line) {
+            self.push_residue(residue);
+        }
+    }
+
+    fn finish_record(
+        &mut self,
+        id: String,
+        line: usize,
+        record_index: usize,
+    ) -> Result<(), BioRsError> {
+        if self.current_length == 0 {
+            return Err(BioRsError::MissingSequence {
+                id,
+                line,
+                record_index,
+            });
+        }
+
+        self.summary.records += 1;
+        self.summary.total_length += self.current_length;
+        self.summary.warning_count += self.current_warning_count;
+        self.summary.error_count += self.current_error_count;
+        if self.current_warning_count == 0 && self.current_error_count == 0 {
+            self.summary.valid_records += 1;
+        }
+
+        self.current_length = 0;
+        self.current_warning_count = 0;
+        self.current_error_count = 0;
+        Ok(())
+    }
+}
+
+impl SummaryRecordSink {
+    fn push_residue(&mut self, residue: char) {
+        self.current_length += 1;
+        if protein_20_token_id(residue).is_some() {
+            return;
+        }
+
+        if is_ambiguous_residue(residue) {
+            self.current_warning_count += 1;
+        } else {
+            self.current_error_count += 1;
+        }
+    }
+
+    fn push_residue_byte(&mut self, residue: u8) {
+        let residue = residue.to_ascii_uppercase();
+        self.current_length += 1;
+        if protein_20_token_id_byte(residue).is_some() {
+            return;
+        }
+
+        if is_ambiguous_residue_byte(residue) {
+            self.current_warning_count += 1;
+        } else {
+            self.current_error_count += 1;
+        }
     }
 }
 

--- a/packages/rust/biors-core/tests/core_contract.rs
+++ b/packages/rust/biors-core/tests/core_contract.rs
@@ -145,6 +145,20 @@ fn tokenizes_fasta_from_reader_and_reports_input_hash() {
 }
 
 #[test]
+fn summarizes_fasta_from_reader_without_materializing_tokens() {
+    let raw = ">valid\nACDE\n>warn\nXBZ\n>invalid\nA?\n";
+    let output =
+        biors_core::summarize_fasta_records_reader(Cursor::new(raw)).expect("reader summary");
+
+    assert_eq!(output.input_hash, stable_input_hash(raw));
+    assert_eq!(output.summary.records, 3);
+    assert_eq!(output.summary.total_length, 9);
+    assert_eq!(output.summary.valid_records, 1);
+    assert_eq!(output.summary.warning_count, 3);
+    assert_eq!(output.summary.error_count, 1);
+}
+
+#[test]
 fn fixture_corpus_covers_valid_and_invalid_fasta_contracts() {
     let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fasta");
     let valid = fixture_dir.join("valid/mixed_case_whitespace.fasta");

--- a/packages/rust/biors/src/commands.rs
+++ b/packages/rust/biors/src/commands.rs
@@ -3,7 +3,7 @@ use crate::input::{open_fasta_input, read_fixture_observations, read_package_man
 use crate::output::print_success;
 use biors_core::{
     build_model_inputs_checked, inspect_package_manifest, plan_runtime_bridge,
-    summarize_tokenized_proteins, tokenize_fasta_records_reader, validate_fasta_reader_with_hash,
+    summarize_fasta_records_reader, tokenize_fasta_records_reader, validate_fasta_reader_with_hash,
     validate_package_manifest_artifacts, verify_package_outputs_with_observation_base,
     ModelInputPolicy, PaddingPolicy,
 };
@@ -97,10 +97,9 @@ pub(crate) fn run(command: Command) -> Result<(), CliError> {
         },
         Command::Inspect { path } => {
             let reader = open_fasta_input(&path)?;
-            let output = tokenize_fasta_records_reader(reader)
+            let output = summarize_fasta_records_reader(reader)
                 .map_err(|error| CliError::from_fasta_read(path, error))?;
-            let summary = summarize_tokenized_proteins(&output.records);
-            print_success(Some(output.input_hash), summary)?;
+            print_success(Some(output.input_hash), output.summary)?;
         }
         Command::ModelInput {
             max_length,

--- a/packages/rust/biors/tests/release_candidate.rs
+++ b/packages/rust/biors/tests/release_candidate.rs
@@ -49,6 +49,7 @@ fn release_candidate_documentation_surfaces_are_present_and_linked() {
         "CITATION.cff",
         "docs/api-review.md",
         "docs/quickstart.md",
+        "docs/professional-readiness.md",
         "docs/release-candidate-1.0.md",
         "docs/msrv.md",
     ];
@@ -63,6 +64,7 @@ fn release_candidate_documentation_surfaces_are_present_and_linked() {
     let readme = fs::read_to_string(repo.join("README.md")).expect("read README");
     for link in [
         "docs/quickstart.md",
+        "docs/professional-readiness.md",
         "docs/api-review.md",
         "docs/release-candidate-1.0.md",
         "docs/msrv.md",
@@ -70,6 +72,20 @@ fn release_candidate_documentation_surfaces_are_present_and_linked() {
         "CITATION.cff",
     ] {
         assert!(readme.contains(link), "README does not link {link}");
+    }
+
+    let readiness =
+        fs::read_to_string(repo.join("docs/professional-readiness.md")).expect("read readiness");
+    for marker in [
+        "Phase 1",
+        "Phase 2",
+        "Researcher-Ready Scope",
+        "Known Limits",
+    ] {
+        assert!(
+            readiness.contains(marker),
+            "readiness doc missing marker: {marker}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- add a summary-only FASTA reader path and route `biors inspect` through it so inspect no longer materializes token vectors
- add professional readiness documentation covering Phase 1/2 coverage, researcher-ready scope, refactor/performance status, and known limits
- update quickstart/docs/changelog and bump workspace version to v0.12.1

## Verification
- cargo test --locked -p biors-core --test core_contract -- --nocapture
- cargo test --locked -p biors --test release_candidate -- --nocapture
- scripts/check.sh

## Release state
- prepares v0.12.1 patch release
- v0.10.0, v0.11.0, and v0.12.0 are already published and verified
