### PR TITLE
fix: expose CLI version for reproducible installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable pre-1.0 changes are summarized here. GitHub Releases remain the
 source for exact commit lists after tags are published.
 
+## 0.12.2
+
+- Added `biors --version` so installed CLI binaries can be tied back to the
+  exact published package version in notebooks, CI logs, and benchmark records.
+- Documented version verification in the quickstart, CLI contract, and
+  professional-readiness guide.
+
 ## 0.12.1
 
 - Added a release workflow invariant check and fixed crates.io publish ordering

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "biors"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "biors-core",
  "clap",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "biors-core"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bio-rs/bio-rs"
-version = "0.12.1"
+version = "0.12.2"
 
 [workspace.dependencies]
-biors-core = { version = "0.12.1", path = "packages/rust/biors-core" }
+biors-core = { version = "0.12.2", path = "packages/rust/biors-core" }
 clap = { version = "4.5.37", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The goal is to make the input layer around bio-AI models faster, more portable, 
 Install the published CLI:
 
 ```bash
-cargo install biors --version 0.12.1
+cargo install biors --version 0.12.2
+biors --version
 ```
 
 Tokenize a FASTA file:
@@ -286,6 +287,7 @@ Public contract docs:
 
 Delivered:
 
+- `0.12.2`: published CLI `--version` support and version-verification docs for reproducible installs
 - `0.12.1`: release workflow publish-order guard, published CLI quickstart, professional-readiness audit, and summary-only FASTA inspect path
 - `0.12.0`: release-candidate documentation, full workflow e2e coverage, MSRV/citation policy drafts, and changelog
 - `0.11.0`: benchmark reproducibility metadata, generated benchmark report checks, and refreshed speed/memory proof assets

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -4,6 +4,7 @@ This document records the current pre-1.0 CLI and JSON contract surface.
 
 ## Commands
 
+- `biors --version`
 - `biors tokenize <path|->`
 - `biors inspect <path|->`
 - `biors model-input --max-length <usize> [--pad-token-id <u8>] [--padding fixed_length|no_padding] <path|->`
@@ -14,6 +15,8 @@ This document records the current pre-1.0 CLI and JSON contract surface.
 - `biors package verify <manifest> <observations>`
 
 `model-input` tokenizes FASTA records and emits deterministic model-ready `input_ids` plus `attention_mask` records.
+`biors --version` prints the installed CLI package version so workflow logs and
+benchmark records can be tied back to the exact released binary.
 It rejects sequences that still contain residue warnings or errors, so model-ready output cannot silently drop unresolved residues.
 `--max-length` must be greater than zero.
 `tokenize` preserves positional alignment by emitting explicit unknown-token IDs for ambiguous or invalid residues instead of shortening the token vector.

--- a/docs/professional-readiness.md
+++ b/docs/professional-readiness.md
@@ -14,6 +14,7 @@ bio-rs is ready for local and CI use when the workflow is:
 - package manifest inspection and portable asset validation
 - package fixture verification against observed output artifacts
 - reproducible FASTA validation/tokenization benchmarking
+- installed CLI version verification with `biors --version`
 
 The strongest fit today is preprocessing and verification around biological AI
 model inputs. The project should be presented as input-contract infrastructure,
@@ -50,6 +51,8 @@ not as a model inference engine or broad bioinformatics suite.
 - `biors inspect` uses a summary-only reader path so large FASTA inspection no
   longer materializes token vectors just to count records, residues, warnings,
   and errors.
+- The published CLI exposes `biors --version`, which makes installed binary
+  provenance explicit in lab notebooks, CI logs, and benchmark runs.
 - Vocabulary token definitions are static; callers that need only the canonical
   token list can use `protein_20_vocab_tokens()` without rebuilding a `Vec`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ fresh checkout.
 ## Install
 
 ```bash
-cargo install biors --version 0.12.1
+cargo install biors --version 0.12.2
 biors --version
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,6 +7,7 @@ fresh checkout.
 
 ```bash
 cargo install biors --version 0.12.1
+biors --version
 ```
 
 When working inside a source checkout, replace `biors` with

--- a/packages/rust/biors/src/commands.rs
+++ b/packages/rust/biors/src/commands.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 #[command(name = "biors")]
 #[command(about = "Rust/WASM tools for biological AI models.")]
+#[command(version)]
 pub(crate) struct Cli {
     #[arg(long, global = true, help = "Emit machine-readable JSON errors")]
     pub(crate) json: bool,

--- a/packages/rust/biors/tests/cli.rs
+++ b/packages/rust/biors/tests/cli.rs
@@ -4,6 +4,27 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 #[test]
+fn cli_version_flag_reports_published_package_version() {
+    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
+        .arg("--version")
+        .output()
+        .expect("run biors --version");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let stdout = String::from_utf8(output.stdout).expect("version output is UTF-8");
+    assert_eq!(
+        stdout.trim(),
+        format!("biors {}", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
 fn tokenize_multi_fasta_outputs_json_array() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let example = manifest_dir.join("../../../examples/multi.fasta");

--- a/packages/rust/biors/tests/release_candidate.rs
+++ b/packages/rust/biors/tests/release_candidate.rs
@@ -87,6 +87,19 @@ fn release_candidate_documentation_surfaces_are_present_and_linked() {
             "readiness doc missing marker: {marker}"
         );
     }
+
+    let quickstart = fs::read_to_string(repo.join("docs/quickstart.md")).expect("read quickstart");
+    let cli_contract =
+        fs::read_to_string(repo.join("docs/cli-contract.md")).expect("read CLI contract");
+    for (name, contents) in [
+        ("quickstart", quickstart.as_str()),
+        ("CLI contract", cli_contract.as_str()),
+    ] {
+        assert!(
+            contents.contains("biors --version"),
+            "{name} does not document version verification"
+        );
+    }
 }
 
 fn repo_root() -> PathBuf {


### PR DESCRIPTION
## Summary
- add `biors --version` and cover it with a CLI regression test
- document version verification in quickstart, CLI contract, and professional-readiness docs
- prepare v0.12.2 patch release metadata

## Verification
- cargo test --locked -p biors --test cli cli_version_flag_reports_published_package_version -- --nocapture
- cargo test --locked -p biors --test release_candidate release_candidate_documentation_surfaces_are_present_and_linked -- --nocapture
- cargo run --locked -p biors -- --version
- scripts/check.sh

## Readiness review
- Phase 1/2 scope remains implemented for protein FASTA validation, tokenization, model-input JSON, package verification, and reproducible benchmark documentation
- current known limits remain explicitly documented: no model inference backend, Python bindings, nucleotide/structure/chemistry tooling, or hosted workflows
