### PR TITLE
chore(release): prepare v0.12.8

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,4 +6,4 @@ authors:
   - name: "Bio.rs contributors"
 repository-code: "https://github.com/bio-rs/bio-rs"
 license: "MIT OR Apache-2.0"
-version: "0.12.7"
+version: "0.12.8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "biors"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "biors-core",
  "clap",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "biors-core"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bio-rs/bio-rs"
-version = "0.12.7"
+version = "0.12.8"
 
 [workspace.dependencies]
-biors-core = { version = "0.12.7", path = "packages/rust/biors-core" }
+biors-core = { version = "0.12.8", path = "packages/rust/biors-core" }
 clap = { version = "4.5.37", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The goal is to make the input layer around bio-AI models faster, more portable, 
 Install the published CLI:
 
 ```bash
-cargo install biors --version 0.12.7
+cargo install biors --version 0.12.8
 biors --version
 ```
 
@@ -294,6 +294,7 @@ Public contract docs:
 
 Delivered:
 
+- `0.12.8`: biors-core SRP refactor for package, sequence, verification, and FASTA scanner internals with public API docs refreshed
 - `0.12.7`: tokenizer hot-path cleanup, SRP-focused core module split, module-size guardrail, and refreshed benchmark proof assets
 - `0.12.6`: borrowed protein-20 vocabulary API, lowercase-aware token lookup fast path, tokenizer module split, and refreshed benchmark proof assets
 - `0.12.5`: validation-only FASTA reader path, dead analysis-path cleanup, benchmark artifact comparison helper, and refreshed proof assets

--- a/docs/api-review.md
+++ b/docs/api-review.md
@@ -8,7 +8,7 @@ path. It is not a promise that every listed surface is stable today.
 Current candidate surfaces are listed in
 [`public-contract-1.0-candidates.md`](public-contract-1.0-candidates.md).
 
-Reviewed through 0.12.7:
+Reviewed through 0.12.8:
 
 - FASTA parse and reader APIs keep line and record-index diagnostics.
 - Tokenization preserves sequence length with explicit unknown-token IDs.
@@ -31,12 +31,12 @@ Reviewed through 0.12.7:
 Schemas under [`../schemas`](../schemas) are validated by
 `packages/rust/biors/tests/schema_contract.rs`.
 
-Reviewed through 0.12.7:
+Reviewed through 0.12.8:
 
 - CLI success and error envelopes.
 - FASTA validation, inspect, tokenize, and model-input payloads.
 - Package manifest, inspect, validate, bridge, and verify payloads.
-- 0.12.7 changed internal module boundaries only; no JSON schema shape changed.
+- 0.12.8 changed internal module boundaries only; no JSON schema shape changed.
 
 ## Breaking-Change Cleanup
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ fresh checkout.
 ## Install
 
 ```bash
-cargo install biors --version 0.12.7
+cargo install biors --version 0.12.8
 biors --version
 ```
 


### PR DESCRIPTION
## Summary
- Bump workspace packages and lockfile to 0.12.8.
- Refresh README, quickstart, citation metadata, and API review notes for the SRP refactor release.

## Test Plan
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked -p biors-core --no-deps`
- `scripts/check.sh`
