### PR TITLE
feat(sequence): add DNA and RNA validation policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "biors"
-version = "0.12.8"
+version = "0.13.0"
 dependencies = [
  "biors-core",
  "clap",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "biors-core"
-version = "0.12.8"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bio-rs/bio-rs"
-version = "0.12.8"
+version = "0.13.0"
 
 [workspace.dependencies]
-biors-core = { version = "0.12.8", path = "packages/rust/biors-core" }
+biors-core = { version = "0.13.0", path = "packages/rust/biors-core" }
 clap = { version = "4.5.37", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The goal is to make the input layer around bio-AI models faster, more portable, 
 Install the published CLI:
 
 ```bash
-cargo install biors --version 0.12.8
+cargo install biors --version 0.13.0
 biors --version
 ```
 
@@ -294,6 +294,7 @@ Public contract docs:
 
 Delivered:
 
+- `0.13.0`: biors-core DNA/RNA validation draft with `SequenceKind`, IUPAC nucleotide policies, auto-detection, and diagnostic sequence issues
 - `0.12.8`: biors-core SRP refactor for package, sequence, verification, and FASTA scanner internals with public API docs refreshed
 - `0.12.7`: tokenizer hot-path cleanup, SRP-focused core module split, module-size guardrail, and refreshed benchmark proof assets
 - `0.12.6`: borrowed protein-20 vocabulary API, lowercase-aware token lookup fast path, tokenizer module split, and refreshed benchmark proof assets

--- a/docs/api-review.md
+++ b/docs/api-review.md
@@ -8,10 +8,13 @@ path. It is not a promise that every listed surface is stable today.
 Current candidate surfaces are listed in
 [`public-contract-1.0-candidates.md`](public-contract-1.0-candidates.md).
 
-Reviewed through 0.12.8:
+Reviewed through 0.13.0:
 
 - FASTA parse and reader APIs keep line and record-index diagnostics.
 - Tokenization preserves sequence length with explicit unknown-token IDs.
+- `biors-core` exposes kind-aware sequence validation for Protein, DNA, and RNA
+  through `SequenceKind`, IUPAC nucleotide alphabet policies, and stable
+  sequence diagnostics.
 - Protein-20 vocabulary can be borrowed through `protein_20_vocabulary` and
   `ProteinTokenizer::vocabulary_ref` without changing the owned vocabulary API.
 - FASTA inspect summaries can be produced from reader input without
@@ -31,7 +34,7 @@ Reviewed through 0.12.8:
 Schemas under [`../schemas`](../schemas) are validated by
 `packages/rust/biors/tests/schema_contract.rs`.
 
-Reviewed through 0.12.8:
+Reviewed through 0.13.0:
 
 - CLI success and error envelopes.
 - FASTA validation, inspect, tokenize, and model-input payloads.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ fresh checkout.
 ## Install
 
 ```bash
-cargo install biors --version 0.12.8
+cargo install biors --version 0.13.0
 biors --version
 ```
 

--- a/packages/rust/biors-core/Cargo.toml
+++ b/packages/rust/biors-core/Cargo.toml
@@ -4,9 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Core protein input contracts and tokenization for bio-rs."
+description = "Core biological sequence validation and protein tokenization contracts for bio-rs."
 readme = "../../../README.md"
-keywords = ["bioinformatics", "protein", "tokenizer", "ai"]
+keywords = ["bioinformatics", "sequence", "tokenizer", "ai"]
 categories = ["science"]
 
 [dependencies]

--- a/packages/rust/biors-core/src/error.rs
+++ b/packages/rust/biors-core/src/error.rs
@@ -1,6 +1,20 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Common interface for errors and validation issues that expose stable CLI/API diagnostics.
+pub trait Diagnostic {
+    /// Stable machine-readable diagnostic code.
+    fn code(&self) -> &'static str;
+
+    /// Human-readable diagnostic message.
+    fn message(&self) -> String;
+
+    /// Optional structured location for the diagnostic.
+    fn location(&self) -> Option<ErrorLocation> {
+        None
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Machine-readable location metadata for a parse or validation error.
 pub struct ErrorLocation {
@@ -106,6 +120,20 @@ impl fmt::Display for BioRsError {
 
 impl std::error::Error for BioRsError {}
 
+impl Diagnostic for BioRsError {
+    fn code(&self) -> &'static str {
+        BioRsError::code(self)
+    }
+
+    fn message(&self) -> String {
+        self.to_string()
+    }
+
+    fn location(&self) -> Option<ErrorLocation> {
+        BioRsError::location(self)
+    }
+}
+
 #[derive(Debug)]
 /// Error type for streaming FASTA reader APIs.
 pub enum FastaReadError {
@@ -135,6 +163,23 @@ impl fmt::Display for FastaReadError {
 }
 
 impl std::error::Error for FastaReadError {}
+
+impl Diagnostic for FastaReadError {
+    fn code(&self) -> &'static str {
+        FastaReadError::code(self)
+    }
+
+    fn message(&self) -> String {
+        self.to_string()
+    }
+
+    fn location(&self) -> Option<ErrorLocation> {
+        match self {
+            Self::Parse(error) => error.location(),
+            Self::Io(_) => None,
+        }
+    }
+}
 
 impl From<BioRsError> for FastaReadError {
     fn from(error: BioRsError) -> Self {

--- a/packages/rust/biors-core/src/lib.rs
+++ b/packages/rust/biors-core/src/lib.rs
@@ -1,8 +1,8 @@
-//! Core Rust APIs for bio-rs protein FASTA validation, tokenization, model input
+//! Core Rust APIs for bio-rs biological sequence validation, protein tokenization, model input
 //! construction, package manifests, and package fixture verification.
 //!
-//! FASTA reader paths prefer an ASCII byte-level scanner for the common protein
-//! FASTA case. Non-ASCII sequence lines fall back to UTF-8 validation so public
+//! FASTA reader paths prefer an ASCII byte-level scanner for common biological
+//! FASTA input. Non-ASCII sequence lines fall back to UTF-8 validation so public
 //! Unicode behavior remains explicit and test-covered.
 
 /// Structured error types used by parsing and reader APIs.
@@ -21,7 +21,7 @@ pub mod tokenizer;
 /// Package fixture verification and stable hashing helpers.
 pub mod verification;
 
-pub use error::{BioRsError, ErrorLocation, FastaReadError};
+pub use error::{BioRsError, Diagnostic, ErrorLocation, FastaReadError};
 pub use fasta::{
     parse_fasta_records, parse_fasta_records_reader, validate_fasta_input, validate_fasta_reader,
     validate_fasta_reader_with_hash, ParsedFastaInput, ValidatedFastaInput,
@@ -42,8 +42,10 @@ pub use package::{
     TokenAsset,
 };
 pub use sequence::{
-    normalize_sequence, validate_protein_sequence, ProteinSequence, ResidueIssue,
-    SequenceValidationReport, ValidatedSequence,
+    detect_sequence_kind, normalize_sequence, validate_protein_sequence, validate_sequence_record,
+    AlphabetPolicy, ProteinSequence, ResidueIssue, SequenceKind, SequenceKindSelection,
+    SequenceRecord, SequenceValidationIssue, SequenceValidationIssueCode, SequenceValidationReport,
+    SymbolClass, ValidatedSequence, ValidatedSequenceRecord,
 };
 pub use tokenizer::{
     load_protein_20_vocab, load_vocab_json, protein_20_unknown_token_policy,

--- a/packages/rust/biors-core/src/sequence.rs
+++ b/packages/rust/biors-core/src/sequence.rs
@@ -1,11 +1,17 @@
-//! Protein sequence types, normalization, residue policy, and validation reports.
+//! Biological sequence types, normalization, alphabet policies, and validation reports.
 
+mod alphabet;
+mod detection;
+mod kind;
 mod normalization;
 mod report;
 mod residue;
 mod types;
 mod validation;
 
+pub use alphabet::{AlphabetPolicy, SymbolClass};
+pub use detection::detect_sequence_kind;
+pub use kind::{SequenceKind, SequenceKindSelection};
 pub use normalization::normalize_sequence;
 pub(crate) use normalization::{
     append_normalized_sequence, append_normalized_sequence_bytes, normalized_residues,
@@ -13,5 +19,9 @@ pub(crate) use normalization::{
 pub use report::summarize_validated_sequences;
 pub(crate) use residue::{is_ambiguous_residue, is_protein_20_residue};
 pub use residue::{AMBIGUOUS_RESIDUES, PROTEIN_20, PROTEIN_20_RESIDUES};
-pub use types::{ProteinSequence, ResidueIssue, SequenceValidationReport, ValidatedSequence};
-pub use validation::validate_protein_sequence;
+pub use types::{
+    ProteinSequence, ResidueIssue, SequenceRecord, SequenceValidationIssue,
+    SequenceValidationIssueCode, SequenceValidationReport, ValidatedSequence,
+    ValidatedSequenceRecord,
+};
+pub use validation::{validate_protein_sequence, validate_sequence_record};

--- a/packages/rust/biors-core/src/sequence/alphabet.rs
+++ b/packages/rust/biors-core/src/sequence/alphabet.rs
@@ -1,0 +1,77 @@
+use super::kind::SequenceKind;
+use super::residue::{is_ambiguous_residue, is_protein_20_residue};
+
+/// Classification of one normalized sequence symbol under an alphabet policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SymbolClass {
+    /// Supported canonical residue or base.
+    Standard,
+    /// Supported ambiguous IUPAC code that should be surfaced as a warning.
+    Ambiguous,
+    /// Unsupported symbol for the selected sequence kind.
+    Invalid,
+}
+
+/// Alphabet policy for one biological sequence kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AlphabetPolicy {
+    kind: SequenceKind,
+}
+
+impl AlphabetPolicy {
+    /// Return the alphabet policy for a sequence kind.
+    pub const fn for_kind(kind: SequenceKind) -> Self {
+        Self { kind }
+    }
+
+    /// Return the sequence kind covered by this policy.
+    pub const fn kind(self) -> SequenceKind {
+        self.kind
+    }
+
+    /// Return the stable policy name used in JSON reports.
+    pub const fn name(self) -> &'static str {
+        self.kind.alphabet_name()
+    }
+
+    /// Classify a symbol after ASCII uppercasing.
+    pub fn classify(self, symbol: char) -> SymbolClass {
+        if symbol.is_ascii() {
+            return self.classify_byte(symbol as u8);
+        }
+
+        SymbolClass::Invalid
+    }
+
+    /// Classify an ASCII byte without allocating.
+    pub fn classify_byte(self, symbol: u8) -> SymbolClass {
+        let symbol = symbol.to_ascii_uppercase();
+        match self.kind {
+            SequenceKind::Protein => classify_protein_byte(symbol),
+            SequenceKind::Dna => classify_nucleotide_byte(symbol, b'T'),
+            SequenceKind::Rna => classify_nucleotide_byte(symbol, b'U'),
+        }
+    }
+}
+
+fn classify_protein_byte(symbol: u8) -> SymbolClass {
+    let symbol = symbol as char;
+    if is_protein_20_residue(symbol) {
+        SymbolClass::Standard
+    } else if is_ambiguous_residue(symbol) {
+        SymbolClass::Ambiguous
+    } else {
+        SymbolClass::Invalid
+    }
+}
+
+fn classify_nucleotide_byte(symbol: u8, thymine_or_uracil: u8) -> SymbolClass {
+    match symbol {
+        b'A' | b'C' | b'G' => SymbolClass::Standard,
+        value if value == thymine_or_uracil => SymbolClass::Standard,
+        b'R' | b'Y' | b'S' | b'W' | b'K' | b'M' | b'B' | b'D' | b'H' | b'V' | b'N' => {
+            SymbolClass::Ambiguous
+        }
+        _ => SymbolClass::Invalid,
+    }
+}

--- a/packages/rust/biors-core/src/sequence/detection.rs
+++ b/packages/rust/biors-core/src/sequence/detection.rs
@@ -1,0 +1,100 @@
+use super::{AlphabetPolicy, SequenceKind, SymbolClass};
+
+/// Detect the most likely sequence kind from normalized biological symbols.
+pub fn detect_sequence_kind(sequence: &str) -> SequenceKind {
+    let mut evidence = KindEvidence::default();
+
+    if sequence.is_ascii() {
+        for byte in sequence.bytes() {
+            if byte.is_ascii_whitespace() {
+                continue;
+            }
+            evidence.observe_byte(byte.to_ascii_uppercase());
+        }
+    } else {
+        for symbol in sequence
+            .chars()
+            .filter(|symbol| !symbol.is_whitespace())
+            .map(|symbol| symbol.to_ascii_uppercase())
+        {
+            evidence.observe_char(symbol);
+        }
+    }
+
+    evidence.detect()
+}
+
+#[derive(Default)]
+struct KindEvidence {
+    protein_errors: usize,
+    dna_errors: usize,
+    rna_errors: usize,
+    has_u: bool,
+    has_t: bool,
+    has_protein_only_symbol: bool,
+}
+
+impl KindEvidence {
+    fn observe_byte(&mut self, symbol: u8) {
+        self.observe_classifications(
+            symbol as char,
+            AlphabetPolicy::for_kind(SequenceKind::Protein).classify_byte(symbol),
+            AlphabetPolicy::for_kind(SequenceKind::Dna).classify_byte(symbol),
+            AlphabetPolicy::for_kind(SequenceKind::Rna).classify_byte(symbol),
+        );
+    }
+
+    fn observe_char(&mut self, symbol: char) {
+        self.observe_classifications(
+            symbol,
+            AlphabetPolicy::for_kind(SequenceKind::Protein).classify(symbol),
+            AlphabetPolicy::for_kind(SequenceKind::Dna).classify(symbol),
+            AlphabetPolicy::for_kind(SequenceKind::Rna).classify(symbol),
+        );
+    }
+
+    fn observe_classifications(
+        &mut self,
+        symbol: char,
+        protein: SymbolClass,
+        dna: SymbolClass,
+        rna: SymbolClass,
+    ) {
+        if protein == SymbolClass::Invalid {
+            self.protein_errors += 1;
+        }
+        if dna == SymbolClass::Invalid {
+            self.dna_errors += 1;
+        }
+        if rna == SymbolClass::Invalid {
+            self.rna_errors += 1;
+        }
+
+        self.has_u |= symbol == 'U';
+        self.has_t |= symbol == 'T';
+        self.has_protein_only_symbol |= protein != SymbolClass::Invalid
+            && dna == SymbolClass::Invalid
+            && rna == SymbolClass::Invalid;
+    }
+
+    fn detect(self) -> SequenceKind {
+        let min_errors = self
+            .protein_errors
+            .min(self.dna_errors)
+            .min(self.rna_errors);
+
+        if self.has_protein_only_symbol && self.protein_errors == min_errors {
+            return SequenceKind::Protein;
+        }
+        if self.has_u && !self.has_t && self.rna_errors == min_errors {
+            return SequenceKind::Rna;
+        }
+        if self.dna_errors == min_errors {
+            return SequenceKind::Dna;
+        }
+        if self.rna_errors == min_errors {
+            return SequenceKind::Rna;
+        }
+        SequenceKind::Protein
+    }
+}

--- a/packages/rust/biors-core/src/sequence/kind.rs
+++ b/packages/rust/biors-core/src/sequence/kind.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Biological sequence alphabet family used for validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SequenceKind {
+    /// Protein sequence validated with the built-in protein-20 policy.
+    Protein,
+    /// DNA sequence validated with standard and ambiguous IUPAC DNA symbols.
+    Dna,
+    /// RNA sequence validated with standard and ambiguous IUPAC RNA symbols.
+    Rna,
+}
+
+impl SequenceKind {
+    /// Return the stable alphabet policy name for this kind.
+    pub const fn alphabet_name(self) -> &'static str {
+        match self {
+            Self::Protein => "protein-20",
+            Self::Dna => "dna-iupac",
+            Self::Rna => "rna-iupac",
+        }
+    }
+
+    /// Return the display name used in human-readable diagnostics.
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::Protein => "protein",
+            Self::Dna => "DNA",
+            Self::Rna => "RNA",
+        }
+    }
+}
+
+impl fmt::Display for SequenceKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Protein => write!(f, "protein"),
+            Self::Dna => write!(f, "dna"),
+            Self::Rna => write!(f, "rna"),
+        }
+    }
+}
+
+/// User selection for kind-aware validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SequenceKindSelection {
+    /// Detect each sequence kind from its normalized symbols.
+    Auto,
+    /// Validate with an explicit kind, even if another kind would fit better.
+    Explicit(SequenceKind),
+}
+
+impl SequenceKindSelection {
+    /// Return the explicit kind when detection is disabled.
+    pub const fn explicit_kind(self) -> Option<SequenceKind> {
+        match self {
+            Self::Auto => None,
+            Self::Explicit(kind) => Some(kind),
+        }
+    }
+}

--- a/packages/rust/biors-core/src/sequence/types.rs
+++ b/packages/rust/biors-core/src/sequence/types.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+use super::kind::SequenceKind;
+use crate::Diagnostic;
+
 /// A named protein sequence parsed from FASTA or supplied by callers.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProteinSequence {
@@ -48,4 +51,121 @@ pub struct SequenceValidationReport {
     pub error_count: usize,
     /// Per-record validation details.
     pub sequences: Vec<ValidatedSequence>,
+}
+
+/// A normalized biological sequence with an assigned sequence kind.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SequenceRecord {
+    /// Sequence identifier.
+    pub id: String,
+    /// Normalized sequence symbols with whitespace removed and ASCII letters uppercased.
+    pub sequence: String,
+    /// Biological sequence kind used for validation.
+    pub kind: SequenceKind,
+}
+
+impl SequenceRecord {
+    /// Build a normalized sequence record for kind-aware validation.
+    pub fn new(id: impl Into<String>, sequence: impl AsRef<str>, kind: SequenceKind) -> Self {
+        Self {
+            id: id.into(),
+            sequence: super::normalize_sequence(sequence.as_ref()),
+            kind,
+        }
+    }
+}
+
+/// Stable diagnostic code for kind-aware sequence validation issues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SequenceValidationIssueCode {
+    /// Supported ambiguous IUPAC symbol.
+    AmbiguousSymbol,
+    /// Unsupported symbol for the selected kind.
+    InvalidSymbol,
+}
+
+impl SequenceValidationIssueCode {
+    /// Return the stable diagnostic code string.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AmbiguousSymbol => "sequence.ambiguous_symbol",
+            Self::InvalidSymbol => "sequence.invalid_symbol",
+        }
+    }
+}
+
+/// Kind-aware sequence validation warning or error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SequenceValidationIssue {
+    /// Normalized symbol that caused the issue.
+    pub symbol: char,
+    /// One-based position in the normalized sequence.
+    pub position: usize,
+    /// Sequence kind used when classifying this symbol.
+    pub kind: SequenceKind,
+    /// Stable machine-readable issue code.
+    pub code: SequenceValidationIssueCode,
+    /// Human-readable issue message.
+    pub message: String,
+}
+
+impl SequenceValidationIssue {
+    /// Create an ambiguous-symbol warning.
+    pub fn ambiguous(symbol: char, position: usize, kind: SequenceKind) -> Self {
+        Self {
+            symbol,
+            position,
+            kind,
+            code: SequenceValidationIssueCode::AmbiguousSymbol,
+            message: format!(
+                "{} symbol '{symbol}' at position {position} is ambiguous IUPAC code",
+                kind.display_name()
+            ),
+        }
+    }
+
+    /// Create an invalid-symbol error.
+    pub fn invalid(symbol: char, position: usize, kind: SequenceKind) -> Self {
+        Self {
+            symbol,
+            position,
+            kind,
+            code: SequenceValidationIssueCode::InvalidSymbol,
+            message: format!(
+                "{} symbol '{symbol}' at position {position} is not supported by {}",
+                kind.display_name(),
+                kind.alphabet_name()
+            ),
+        }
+    }
+}
+
+impl Diagnostic for SequenceValidationIssue {
+    fn code(&self) -> &'static str {
+        self.code.as_str()
+    }
+
+    fn message(&self) -> String {
+        self.message.clone()
+    }
+}
+
+/// Validation result for one kind-aware biological sequence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidatedSequenceRecord {
+    /// Sequence identifier.
+    pub id: String,
+    /// Normalized sequence that was validated.
+    pub sequence: String,
+    /// Biological sequence kind used for validation.
+    pub kind: SequenceKind,
+    /// Alphabet policy used for validation.
+    pub alphabet: String,
+    /// True when the sequence has no warnings and no errors.
+    pub valid: bool,
+    /// Ambiguous but recognized symbols for the selected kind.
+    pub warnings: Vec<SequenceValidationIssue>,
+    /// Symbols outside the selected kind's alphabet and ambiguity policy.
+    pub errors: Vec<SequenceValidationIssue>,
 }

--- a/packages/rust/biors-core/src/sequence/validation.rs
+++ b/packages/rust/biors-core/src/sequence/validation.rs
@@ -1,6 +1,7 @@
+use super::{is_ambiguous_residue, is_protein_20_residue};
 use super::{
-    is_ambiguous_residue, is_protein_20_residue, ProteinSequence, ResidueIssue, ValidatedSequence,
-    PROTEIN_20,
+    AlphabetPolicy, ProteinSequence, ResidueIssue, SequenceRecord, SequenceValidationIssue,
+    SymbolClass, ValidatedSequence, ValidatedSequenceRecord, PROTEIN_20,
 };
 
 /// Validate one normalized protein sequence against the `protein-20` policy.
@@ -28,5 +29,67 @@ pub fn validate_protein_sequence(protein: &ProteinSequence) -> ValidatedSequence
         valid: warnings.is_empty() && errors.is_empty(),
         warnings,
         errors,
+    }
+}
+
+/// Validate one normalized biological sequence against its assigned alphabet policy.
+pub fn validate_sequence_record(record: &SequenceRecord) -> ValidatedSequenceRecord {
+    let policy = AlphabetPolicy::for_kind(record.kind);
+    let mut warnings = Vec::new();
+    let mut errors = Vec::new();
+    let mut sequence = String::with_capacity(record.sequence.len());
+    let mut position = 0;
+
+    if record.sequence.is_ascii() {
+        for byte in record.sequence.bytes() {
+            if byte.is_ascii_whitespace() {
+                continue;
+            }
+            let symbol = byte.to_ascii_uppercase() as char;
+            push_kind_issue(symbol, &mut position, policy, &mut warnings, &mut errors);
+            sequence.push(symbol);
+        }
+    } else {
+        for symbol in super::normalized_residues(&record.sequence) {
+            push_kind_issue(symbol, &mut position, policy, &mut warnings, &mut errors);
+            sequence.push(symbol);
+        }
+    }
+
+    ValidatedSequenceRecord {
+        id: record.id.clone(),
+        sequence,
+        kind: record.kind,
+        alphabet: policy.name().to_string(),
+        valid: warnings.is_empty() && errors.is_empty(),
+        warnings,
+        errors,
+    }
+}
+
+fn push_kind_issue(
+    symbol: char,
+    position: &mut usize,
+    policy: AlphabetPolicy,
+    warnings: &mut Vec<SequenceValidationIssue>,
+    errors: &mut Vec<SequenceValidationIssue>,
+) {
+    *position += 1;
+    match policy.classify(symbol) {
+        SymbolClass::Standard => {}
+        SymbolClass::Ambiguous => {
+            warnings.push(SequenceValidationIssue::ambiguous(
+                symbol,
+                *position,
+                policy.kind(),
+            ));
+        }
+        SymbolClass::Invalid => {
+            errors.push(SequenceValidationIssue::invalid(
+                symbol,
+                *position,
+                policy.kind(),
+            ));
+        }
     }
 }

--- a/packages/rust/biors-core/tests/sequence_phase3.rs
+++ b/packages/rust/biors-core/tests/sequence_phase3.rs
@@ -1,0 +1,85 @@
+use biors_core::{
+    detect_sequence_kind, validate_sequence_record, AlphabetPolicy, Diagnostic, SequenceKind,
+    SequenceKindSelection, SequenceRecord, SymbolClass,
+};
+
+#[test]
+fn sequence_kind_serializes_as_stable_lowercase_names() {
+    assert_eq!(
+        serde_json::to_string(&SequenceKind::Protein).expect("serialize protein kind"),
+        r#""protein""#
+    );
+    assert_eq!(
+        serde_json::to_string(&SequenceKind::Dna).expect("serialize DNA kind"),
+        r#""dna""#
+    );
+    assert_eq!(
+        serde_json::to_string(&SequenceKind::Rna).expect("serialize RNA kind"),
+        r#""rna""#
+    );
+    assert_eq!(SequenceKind::Dna.alphabet_name(), "dna-iupac");
+    assert_eq!(SequenceKind::Rna.alphabet_name(), "rna-iupac");
+}
+
+#[test]
+fn nucleotide_policies_classify_standard_and_ambiguous_iupac_codes() {
+    let dna = AlphabetPolicy::for_kind(SequenceKind::Dna);
+    let rna = AlphabetPolicy::for_kind(SequenceKind::Rna);
+
+    for base in ['A', 'C', 'G', 'T'] {
+        assert_eq!(dna.classify(base), SymbolClass::Standard, "{base}");
+    }
+    for base in ['R', 'Y', 'S', 'W', 'K', 'M', 'B', 'D', 'H', 'V', 'N'] {
+        assert_eq!(dna.classify(base), SymbolClass::Ambiguous, "{base}");
+        assert_eq!(rna.classify(base), SymbolClass::Ambiguous, "{base}");
+    }
+    assert_eq!(dna.classify('U'), SymbolClass::Invalid);
+
+    for base in ['A', 'C', 'G', 'U'] {
+        assert_eq!(rna.classify(base), SymbolClass::Standard, "{base}");
+    }
+    assert_eq!(rna.classify('T'), SymbolClass::Invalid);
+}
+
+#[test]
+fn validates_dna_and_rna_sequences_with_kind_specific_diagnostics() {
+    let dna = SequenceRecord::new("dna1", "acgtnu?", SequenceKind::Dna);
+    let rna = SequenceRecord::new("rna1", "acgun t?", SequenceKind::Rna);
+
+    let dna_report = validate_sequence_record(&dna);
+    assert_eq!(dna_report.kind, SequenceKind::Dna);
+    assert_eq!(dna_report.alphabet, "dna-iupac");
+    assert_eq!(dna_report.sequence, "ACGTNU?");
+    assert_eq!(dna_report.warnings.len(), 1);
+    assert_eq!(dna_report.warnings[0].symbol, 'N');
+    assert_eq!(dna_report.warnings[0].position, 5);
+    assert_eq!(dna_report.warnings[0].code(), "sequence.ambiguous_symbol");
+    assert_eq!(dna_report.errors.len(), 2);
+    assert_eq!(dna_report.errors[0].symbol, 'U');
+    assert_eq!(dna_report.errors[0].code(), "sequence.invalid_symbol");
+
+    let rna_report = validate_sequence_record(&rna);
+    assert_eq!(rna_report.kind, SequenceKind::Rna);
+    assert_eq!(rna_report.alphabet, "rna-iupac");
+    assert_eq!(rna_report.sequence, "ACGUNT?");
+    assert_eq!(rna_report.warnings[0].symbol, 'N');
+    assert_eq!(rna_report.errors[0].symbol, 'T');
+    assert!(rna_report.errors[0].message().contains("RNA"));
+}
+
+#[test]
+fn auto_detection_chooses_fewest_errors_with_dna_tie_default() {
+    assert_eq!(detect_sequence_kind("ACGN"), SequenceKind::Dna);
+    assert_eq!(detect_sequence_kind("NNNN"), SequenceKind::Dna);
+    assert_eq!(detect_sequence_kind("ACGU"), SequenceKind::Rna);
+    assert_eq!(detect_sequence_kind("MEEPQSDPSV"), SequenceKind::Protein);
+}
+
+#[test]
+fn sequence_kind_selection_distinguishes_auto_from_explicit_kinds() {
+    assert_eq!(SequenceKindSelection::Auto.explicit_kind(), None);
+    assert_eq!(
+        SequenceKindSelection::Explicit(SequenceKind::Protein).explicit_kind(),
+        Some(SequenceKind::Protein)
+    );
+}


### PR DESCRIPTION
## Summary
- add `SequenceKind`, `SequenceKindSelection`, `AlphabetPolicy`, and kind-aware sequence records
- add DNA/RNA IUPAC validation with ambiguous-symbol diagnostics
- add `Diagnostic` trait for parse/read errors and sequence validation issues
- prepare workspace metadata for v0.13.0

## Verification
- cargo test --locked -p biors-core
- RUSTDOCFLAGS="-D warnings" cargo doc --locked -p biors-core --no-deps
- scripts/check-fast.sh
- scripts/check.sh
