### PR TITLE
feat(fasta): support multi-alphabet validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "biors"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "biors-core",
  "clap",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "biors-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bio-rs/bio-rs"
-version = "0.13.0"
+version = "0.14.0"
 
 [workspace.dependencies]
-biors-core = { version = "0.13.0", path = "packages/rust/biors-core" }
+biors-core = { version = "0.14.0", path = "packages/rust/biors-core" }
 clap = { version = "4.5.37", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The goal is to make the input layer around bio-AI models faster, more portable, 
 Install the published CLI:
 
 ```bash
-cargo install biors --version 0.13.0
+cargo install biors --version 0.14.0
 biors --version
 ```
 
@@ -294,6 +294,7 @@ Public contract docs:
 
 Delivered:
 
+- `0.14.0`: multi-alphabet FASTA validation with per-record kind assignment, `--kind` CLI override, mixed-kind summaries, and updated FASTA validation schema
 - `0.13.0`: biors-core DNA/RNA validation draft with `SequenceKind`, IUPAC nucleotide policies, auto-detection, and diagnostic sequence issues
 - `0.12.8`: biors-core SRP refactor for package, sequence, verification, and FASTA scanner internals with public API docs refreshed
 - `0.12.7`: tokenizer hot-path cleanup, SRP-focused core module split, module-size guardrail, and refreshed benchmark proof assets

--- a/docs/api-review.md
+++ b/docs/api-review.md
@@ -8,13 +8,15 @@ path. It is not a promise that every listed surface is stable today.
 Current candidate surfaces are listed in
 [`public-contract-1.0-candidates.md`](public-contract-1.0-candidates.md).
 
-Reviewed through 0.13.0:
+Reviewed through 0.14.0:
 
 - FASTA parse and reader APIs keep line and record-index diagnostics.
 - Tokenization preserves sequence length with explicit unknown-token IDs.
 - `biors-core` exposes kind-aware sequence validation for Protein, DNA, and RNA
   through `SequenceKind`, IUPAC nucleotide alphabet policies, and stable
   sequence diagnostics.
+- FASTA validation can assign sequence kind per record with auto-detection or an
+  explicit override while preserving the buffered reader hash path.
 - Protein-20 vocabulary can be borrowed through `protein_20_vocabulary` and
   `ProteinTokenizer::vocabulary_ref` without changing the owned vocabulary API.
 - FASTA inspect summaries can be produced from reader input without
@@ -34,10 +36,12 @@ Reviewed through 0.13.0:
 Schemas under [`../schemas`](../schemas) are validated by
 `packages/rust/biors/tests/schema_contract.rs`.
 
-Reviewed through 0.13.0:
+Reviewed through 0.14.0:
 
 - CLI success and error envelopes.
 - FASTA validation, inspect, tokenize, and model-input payloads.
+- FASTA validation schema includes per-record `kind`, `alphabet`, `kind_counts`,
+  and typed sequence issue objects.
 - Package manifest, inspect, validate, bridge, and verify payloads.
 - 0.12.8 changed internal module boundaries only; no JSON schema shape changed.
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -8,7 +8,7 @@ This document records the current pre-1.0 CLI and JSON contract surface.
 - `biors tokenize <path|->`
 - `biors inspect <path|->`
 - `biors model-input --max-length <usize> [--pad-token-id <u8>] [--padding fixed_length|no_padding] <path|->`
-- `biors fasta validate <path|->`
+- `biors fasta validate [--kind protein|dna|rna|auto] <path|->`
 - `biors package inspect <manifest>`
 - `biors package validate <manifest|->`
 - `biors package bridge <manifest>`
@@ -20,6 +20,10 @@ benchmark records can be tied back to the exact released binary.
 It rejects sequences that still contain residue warnings or errors, so model-ready output cannot silently drop unresolved residues.
 `--max-length` must be greater than zero.
 `tokenize` preserves positional alignment by emitting explicit unknown-token IDs for ambiguous or invalid residues instead of shortening the token vector.
+FASTA validation defaults to the protein policy for pre-0.14 compatibility.
+Passing `--kind dna`, `--kind rna`, or `--kind protein` applies one policy to
+all records; `--kind auto` assigns `protein`, `dna`, or `rna` per record and
+defaults ambiguous nucleotide-only ties such as `ACGN` to DNA.
 FASTA-backed CLI commands read through buffered reader APIs and compute the legacy `fnv1a64:` input hash during the same pass.
 `inspect` uses a summary-only reader path and does not materialize token vectors
 when it only needs record, residue, warning, and error counts.
@@ -51,6 +55,10 @@ unless they directly hash a user input contract in a later release.
 The `input_hash` field remains `fnv1a64:` for FASTA-backed compatibility. Package manifest checksums and fixture hashes use `sha256:`.
 
 Package validation reports include both the legacy string `issues` list and a typed `structured_issues` list with stable issue codes.
+
+FASTA validation reports include `kind_counts` and per-record `kind` /
+`alphabet` fields. Sequence warnings and errors expose stable issue codes such
+as `ambiguous_symbol` and `invalid_symbol` plus human-readable messages.
 
 `structured_issues` entries use this shape:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ fresh checkout.
 ## Install
 
 ```bash
-cargo install biors --version 0.13.0
+cargo install biors --version 0.14.0
 biors --version
 ```
 

--- a/packages/rust/biors-core/src/fasta.rs
+++ b/packages/rust/biors-core/src/fasta.rs
@@ -8,6 +8,13 @@ use crate::{FastaReadError, ProteinSequence, SequenceValidationReport};
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
 
+mod kind_validation;
+
+pub use kind_validation::{
+    validate_fasta_input_with_kind, validate_fasta_reader_with_kind,
+    validate_fasta_reader_with_kind_and_hash, ValidatedKindAwareFastaInput,
+};
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Parsed FASTA records plus a stable hash of the raw reader input.
 pub struct ParsedFastaInput {

--- a/packages/rust/biors-core/src/fasta/kind_validation.rs
+++ b/packages/rust/biors-core/src/fasta/kind_validation.rs
@@ -1,0 +1,104 @@
+use crate::fasta_scan::{scan_fasta_reader, scan_fasta_str, FastaRecordSink};
+use crate::sequence::{
+    append_normalized_sequence, append_normalized_sequence_bytes, detect_sequence_kind,
+    summarize_validated_sequence_records, KindAwareSequenceValidationReport, SequenceKindSelection,
+    SequenceRecord, ValidatedSequenceRecord,
+};
+use crate::{BioRsError, FastaReadError};
+use serde::{Deserialize, Serialize};
+use std::io::BufRead;
+
+/// Kind-aware FASTA validation report plus a stable hash of the raw reader input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidatedKindAwareFastaInput {
+    /// Stable hash of the exact bytes read from the input stream.
+    pub input_hash: String,
+    /// Aggregate kind-aware sequence validation report.
+    pub report: KindAwareSequenceValidationReport,
+}
+
+/// Validate FASTA text with explicit or per-record detected sequence kinds.
+pub fn validate_fasta_input_with_kind(
+    input: &str,
+    selection: SequenceKindSelection,
+) -> Result<KindAwareSequenceValidationReport, BioRsError> {
+    let mut sink = KindAwareValidatedRecordSink::new(selection);
+    scan_fasta_str(input, &mut sink)?;
+    Ok(sink.finish())
+}
+
+/// Validate FASTA from a buffered reader with explicit or detected sequence kinds.
+pub fn validate_fasta_reader_with_kind<R: BufRead>(
+    reader: R,
+    selection: SequenceKindSelection,
+) -> Result<KindAwareSequenceValidationReport, FastaReadError> {
+    Ok(validate_fasta_reader_with_kind_and_hash(reader, selection)?.report)
+}
+
+/// Validate FASTA from a buffered reader with kind-aware output and raw input hash.
+pub fn validate_fasta_reader_with_kind_and_hash<R: BufRead>(
+    reader: R,
+    selection: SequenceKindSelection,
+) -> Result<ValidatedKindAwareFastaInput, FastaReadError> {
+    let mut sink = KindAwareValidatedRecordSink::new(selection);
+    let input_hash = scan_fasta_reader(reader, &mut sink)?;
+    Ok(ValidatedKindAwareFastaInput {
+        input_hash,
+        report: sink.finish(),
+    })
+}
+
+struct KindAwareValidatedRecordSink {
+    selection: SequenceKindSelection,
+    sequences: Vec<ValidatedSequenceRecord>,
+    current_sequence: String,
+}
+
+impl KindAwareValidatedRecordSink {
+    fn new(selection: SequenceKindSelection) -> Self {
+        Self {
+            selection,
+            sequences: Vec::new(),
+            current_sequence: String::new(),
+        }
+    }
+
+    fn finish(self) -> KindAwareSequenceValidationReport {
+        summarize_validated_sequence_records(self.sequences)
+    }
+}
+
+impl FastaRecordSink for KindAwareValidatedRecordSink {
+    fn push_sequence_line(&mut self, line: &str) {
+        append_normalized_sequence(line, &mut self.current_sequence);
+    }
+
+    fn push_sequence_line_bytes(&mut self, line: &[u8]) {
+        append_normalized_sequence_bytes(line, &mut self.current_sequence);
+    }
+
+    fn finish_record(
+        &mut self,
+        id: String,
+        line: usize,
+        record_index: usize,
+    ) -> Result<(), BioRsError> {
+        if self.current_sequence.is_empty() {
+            return Err(BioRsError::MissingSequence {
+                id,
+                line,
+                record_index,
+            });
+        }
+
+        let sequence = std::mem::take(&mut self.current_sequence);
+        let kind = self
+            .selection
+            .explicit_kind()
+            .unwrap_or_else(|| detect_sequence_kind(&sequence));
+        let record = SequenceRecord { id, sequence, kind };
+        self.sequences
+            .push(crate::validate_sequence_record(&record));
+        Ok(())
+    }
+}

--- a/packages/rust/biors-core/src/lib.rs
+++ b/packages/rust/biors-core/src/lib.rs
@@ -23,8 +23,10 @@ pub mod verification;
 
 pub use error::{BioRsError, Diagnostic, ErrorLocation, FastaReadError};
 pub use fasta::{
-    parse_fasta_records, parse_fasta_records_reader, validate_fasta_input, validate_fasta_reader,
-    validate_fasta_reader_with_hash, ParsedFastaInput, ValidatedFastaInput,
+    parse_fasta_records, parse_fasta_records_reader, validate_fasta_input,
+    validate_fasta_input_with_kind, validate_fasta_reader, validate_fasta_reader_with_hash,
+    validate_fasta_reader_with_kind, validate_fasta_reader_with_kind_and_hash, ParsedFastaInput,
+    ValidatedFastaInput, ValidatedKindAwareFastaInput,
 };
 #[allow(deprecated)]
 pub use model_input::build_model_inputs;
@@ -43,9 +45,10 @@ pub use package::{
 };
 pub use sequence::{
     detect_sequence_kind, normalize_sequence, validate_protein_sequence, validate_sequence_record,
-    AlphabetPolicy, ProteinSequence, ResidueIssue, SequenceKind, SequenceKindSelection,
-    SequenceRecord, SequenceValidationIssue, SequenceValidationIssueCode, SequenceValidationReport,
-    SymbolClass, ValidatedSequence, ValidatedSequenceRecord,
+    AlphabetPolicy, KindAwareSequenceValidationReport, ProteinSequence, ResidueIssue, SequenceKind,
+    SequenceKindCounts, SequenceKindSelection, SequenceRecord, SequenceValidationIssue,
+    SequenceValidationIssueCode, SequenceValidationReport, SymbolClass, ValidatedSequence,
+    ValidatedSequenceRecord,
 };
 pub use tokenizer::{
     load_protein_20_vocab, load_vocab_json, protein_20_unknown_token_policy,

--- a/packages/rust/biors-core/src/sequence.rs
+++ b/packages/rust/biors-core/src/sequence.rs
@@ -16,12 +16,12 @@ pub use normalization::normalize_sequence;
 pub(crate) use normalization::{
     append_normalized_sequence, append_normalized_sequence_bytes, normalized_residues,
 };
-pub use report::summarize_validated_sequences;
+pub use report::{summarize_validated_sequence_records, summarize_validated_sequences};
 pub(crate) use residue::{is_ambiguous_residue, is_protein_20_residue};
 pub use residue::{AMBIGUOUS_RESIDUES, PROTEIN_20, PROTEIN_20_RESIDUES};
 pub use types::{
-    ProteinSequence, ResidueIssue, SequenceRecord, SequenceValidationIssue,
-    SequenceValidationIssueCode, SequenceValidationReport, ValidatedSequence,
-    ValidatedSequenceRecord,
+    KindAwareSequenceValidationReport, ProteinSequence, ResidueIssue, SequenceKindCounts,
+    SequenceRecord, SequenceValidationIssue, SequenceValidationIssueCode, SequenceValidationReport,
+    ValidatedSequence, ValidatedSequenceRecord,
 };
 pub use validation::{validate_protein_sequence, validate_sequence_record};

--- a/packages/rust/biors-core/src/sequence/report.rs
+++ b/packages/rust/biors-core/src/sequence/report.rs
@@ -1,4 +1,7 @@
-use super::{SequenceValidationReport, ValidatedSequence};
+use super::{
+    KindAwareSequenceValidationReport, SequenceValidationReport, ValidatedSequence,
+    ValidatedSequenceRecord,
+};
 
 /// Summarize per-record validation results into a batch validation report.
 pub fn summarize_validated_sequences(
@@ -14,4 +17,27 @@ pub fn summarize_validated_sequences(
         error_count: sequences.iter().map(|sequence| sequence.errors.len()).sum(),
         sequences,
     }
+}
+
+/// Summarize kind-aware per-record validation results into a batch report.
+pub fn summarize_validated_sequence_records(
+    sequences: Vec<ValidatedSequenceRecord>,
+) -> KindAwareSequenceValidationReport {
+    let mut report = KindAwareSequenceValidationReport {
+        records: sequences.len(),
+        valid_records: sequences.iter().filter(|sequence| sequence.valid).count(),
+        warning_count: sequences
+            .iter()
+            .map(|sequence| sequence.warnings.len())
+            .sum(),
+        error_count: sequences.iter().map(|sequence| sequence.errors.len()).sum(),
+        sequences,
+        ..KindAwareSequenceValidationReport::default()
+    };
+
+    for sequence in &report.sequences {
+        report.kind_counts.increment(sequence.kind);
+    }
+
+    report
 }

--- a/packages/rust/biors-core/src/sequence/types.rs
+++ b/packages/rust/biors-core/src/sequence/types.rs
@@ -169,3 +169,42 @@ pub struct ValidatedSequenceRecord {
     /// Symbols outside the selected kind's alphabet and ambiguity policy.
     pub errors: Vec<SequenceValidationIssue>,
 }
+
+/// Per-kind record counts for a mixed biological sequence validation batch.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SequenceKindCounts {
+    /// Number of protein records.
+    pub protein: usize,
+    /// Number of DNA records.
+    pub dna: usize,
+    /// Number of RNA records.
+    pub rna: usize,
+}
+
+impl SequenceKindCounts {
+    /// Add one record to the count for `kind`.
+    pub fn increment(&mut self, kind: SequenceKind) {
+        match kind {
+            SequenceKind::Protein => self.protein += 1,
+            SequenceKind::Dna => self.dna += 1,
+            SequenceKind::Rna => self.rna += 1,
+        }
+    }
+}
+
+/// Aggregate validation report for mixed biological sequence batches.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KindAwareSequenceValidationReport {
+    /// Number of input records.
+    pub records: usize,
+    /// Number of records with no warnings and no errors.
+    pub valid_records: usize,
+    /// Total number of ambiguous-symbol warnings.
+    pub warning_count: usize,
+    /// Total number of invalid-symbol errors.
+    pub error_count: usize,
+    /// Per-kind record counts.
+    pub kind_counts: SequenceKindCounts,
+    /// Per-record validation details.
+    pub sequences: Vec<ValidatedSequenceRecord>,
+}

--- a/packages/rust/biors-core/tests/fasta_phase3.rs
+++ b/packages/rust/biors-core/tests/fasta_phase3.rs
@@ -1,0 +1,59 @@
+use biors_core::{
+    stable_input_hash, validate_fasta_input_with_kind, validate_fasta_reader_with_kind_and_hash,
+    Diagnostic, SequenceKind, SequenceKindSelection,
+};
+use std::io::Cursor;
+
+#[test]
+fn fasta_auto_detection_assigns_kind_per_record_and_summarizes_mixed_batches() {
+    let report = validate_fasta_input_with_kind(
+        ">dna\nACGN\n>rna\nACGU\n>protein\nMEEPQSDPSV\n",
+        SequenceKindSelection::Auto,
+    )
+    .expect("valid FASTA envelope");
+
+    assert_eq!(report.records, 3);
+    assert_eq!(report.valid_records, 2);
+    assert_eq!(report.warning_count, 1);
+    assert_eq!(report.error_count, 0);
+    assert_eq!(report.kind_counts.dna, 1);
+    assert_eq!(report.kind_counts.rna, 1);
+    assert_eq!(report.kind_counts.protein, 1);
+    assert_eq!(report.sequences[0].kind, SequenceKind::Dna);
+    assert_eq!(report.sequences[0].alphabet, "dna-iupac");
+    assert_eq!(report.sequences[0].warnings[0].symbol, 'N');
+    assert_eq!(report.sequences[1].kind, SequenceKind::Rna);
+    assert_eq!(report.sequences[2].kind, SequenceKind::Protein);
+}
+
+#[test]
+fn explicit_kind_override_uses_kind_specific_errors() {
+    let report = validate_fasta_input_with_kind(
+        ">rna-looking\nACGU\n",
+        SequenceKindSelection::Explicit(SequenceKind::Dna),
+    )
+    .expect("valid FASTA envelope");
+
+    let record = &report.sequences[0];
+    assert_eq!(record.kind, SequenceKind::Dna);
+    assert_eq!(record.alphabet, "dna-iupac");
+    assert!(!record.valid);
+    assert_eq!(record.errors[0].symbol, 'U');
+    assert_eq!(record.errors[0].code(), "sequence.invalid_symbol");
+    assert!(record.errors[0].message().contains("DNA"));
+}
+
+#[test]
+fn reader_kind_validation_preserves_input_hash_and_unicode_fallback() {
+    let raw = ">unicode\nACΩ\n";
+    let output = validate_fasta_reader_with_kind_and_hash(
+        Cursor::new(raw),
+        SequenceKindSelection::Explicit(SequenceKind::Dna),
+    )
+    .expect("valid UTF-8 FASTA envelope");
+
+    assert_eq!(output.input_hash, stable_input_hash(raw));
+    assert_eq!(output.report.sequences[0].sequence, "ACΩ");
+    assert_eq!(output.report.sequences[0].errors[0].symbol, 'Ω');
+    assert_eq!(output.report.sequences[0].errors[0].position, 3);
+}

--- a/packages/rust/biors/src/commands.rs
+++ b/packages/rust/biors/src/commands.rs
@@ -3,9 +3,10 @@ use crate::input::{open_fasta_input, read_fixture_observations, read_package_man
 use crate::output::print_success;
 use biors_core::{
     build_model_inputs_checked, inspect_package_manifest, plan_runtime_bridge,
-    summarize_fasta_records_reader, tokenize_fasta_records_reader, validate_fasta_reader_with_hash,
-    validate_package_manifest_artifacts, verify_package_outputs_with_observation_base,
-    ModelInputPolicy, PaddingPolicy,
+    summarize_fasta_records_reader, tokenize_fasta_records_reader,
+    validate_fasta_reader_with_kind_and_hash, validate_package_manifest_artifacts,
+    verify_package_outputs_with_observation_base, ModelInputPolicy, PaddingPolicy, SequenceKind,
+    SequenceKindSelection,
 };
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
@@ -50,7 +51,11 @@ pub(crate) enum Command {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum FastaCommand {
-    Validate { path: PathBuf },
+    Validate {
+        #[arg(long, default_value_t = KindArg::Protein, value_enum)]
+        kind: KindArg,
+        path: PathBuf,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -86,12 +91,32 @@ impl From<PaddingArg> for PaddingPolicy {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+pub(crate) enum KindArg {
+    Auto,
+    #[default]
+    Protein,
+    Dna,
+    Rna,
+}
+
+impl From<KindArg> for SequenceKindSelection {
+    fn from(value: KindArg) -> Self {
+        match value {
+            KindArg::Auto => Self::Auto,
+            KindArg::Protein => Self::Explicit(SequenceKind::Protein),
+            KindArg::Dna => Self::Explicit(SequenceKind::Dna),
+            KindArg::Rna => Self::Explicit(SequenceKind::Rna),
+        }
+    }
+}
+
 pub(crate) fn run(command: Command) -> Result<(), CliError> {
     match command {
         Command::Fasta { command } => match command {
-            FastaCommand::Validate { path } => {
+            FastaCommand::Validate { kind, path } => {
                 let reader = open_fasta_input(&path)?;
-                let output = validate_fasta_reader_with_hash(reader)
+                let output = validate_fasta_reader_with_kind_and_hash(reader, kind.into())
                     .map_err(|error| CliError::from_fasta_read(path, error))?;
                 print_success(Some(output.input_hash), output.report)?;
             }

--- a/packages/rust/biors/tests/cli.rs
+++ b/packages/rust/biors/tests/cli.rs
@@ -151,6 +151,65 @@ fn fasta_validate_outputs_validation_report() {
 }
 
 #[test]
+fn fasta_validate_kind_flag_outputs_kind_aware_report() {
+    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
+        .arg("fasta")
+        .arg("validate")
+        .arg("--kind")
+        .arg("dna")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn biors fasta validate")
+        .tap_stdin(">seq1\nACGNU\n");
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+
+    let value: Value = serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(value["data"]["kind_counts"]["dna"], 1);
+    assert_eq!(value["data"]["sequences"][0]["kind"], "dna");
+    assert_eq!(value["data"]["sequences"][0]["alphabet"], "dna-iupac");
+    assert_eq!(
+        value["data"]["sequences"][0]["warnings"][0]["code"],
+        "ambiguous_symbol"
+    );
+    assert_eq!(
+        value["data"]["sequences"][0]["errors"][0]["code"],
+        "invalid_symbol"
+    );
+}
+
+#[test]
+fn fasta_validate_auto_detects_mixed_sequence_kinds() {
+    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
+        .arg("fasta")
+        .arg("validate")
+        .arg("--kind")
+        .arg("auto")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn biors fasta validate")
+        .tap_stdin(">dna\nACGN\n>rna\nACGU\n>protein\nMEEPQSDPSV\n");
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+
+    let value: Value = serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(value["data"]["kind_counts"]["dna"], 1);
+    assert_eq!(value["data"]["kind_counts"]["rna"], 1);
+    assert_eq!(value["data"]["kind_counts"]["protein"], 1);
+    assert_eq!(value["data"]["sequences"][0]["kind"], "dna");
+    assert_eq!(value["data"]["sequences"][1]["kind"], "rna");
+    assert_eq!(value["data"]["sequences"][2]["kind"], "protein");
+}
+
+#[test]
 fn package_inspect_outputs_manifest_summary() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let manifest = manifest_dir.join("../../../examples/protein-package/manifest.json");

--- a/schemas/fasta-validation-output.v0.json
+++ b/schemas/fasta-validation-output.v0.json
@@ -3,38 +3,59 @@
   "$id": "https://bio-rs.dev/schemas/fasta-validation-output.v0.json",
   "title": "bio-rs FASTA validation data payload",
   "type": "object",
-  "required": ["records", "valid_records", "warning_count", "error_count", "sequences"],
+  "required": [
+    "records",
+    "valid_records",
+    "warning_count",
+    "error_count",
+    "kind_counts",
+    "sequences"
+  ],
   "properties": {
     "records": { "type": "integer", "minimum": 0 },
     "valid_records": { "type": "integer", "minimum": 0 },
     "warning_count": { "type": "integer", "minimum": 0 },
     "error_count": { "type": "integer", "minimum": 0 },
+    "kind_counts": {
+      "type": "object",
+      "required": ["protein", "dna", "rna"],
+      "properties": {
+        "protein": { "type": "integer", "minimum": 0 },
+        "dna": { "type": "integer", "minimum": 0 },
+        "rna": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
     "sequences": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "sequence", "alphabet", "valid", "warnings", "errors"],
+        "required": ["id", "sequence", "kind", "alphabet", "valid", "warnings", "errors"],
         "properties": {
           "id": { "type": "string" },
           "sequence": { "type": "string" },
-          "alphabet": { "const": "protein-20" },
+          "kind": { "enum": ["protein", "dna", "rna"] },
+          "alphabet": { "enum": ["protein-20", "dna-iupac", "rna-iupac"] },
           "valid": { "type": "boolean" },
-          "warnings": { "$ref": "#/$defs/residueIssues" },
-          "errors": { "$ref": "#/$defs/residueIssues" }
+          "warnings": { "$ref": "#/$defs/sequenceIssues" },
+          "errors": { "$ref": "#/$defs/sequenceIssues" }
         },
         "additionalProperties": false
       }
     }
   },
   "$defs": {
-    "residueIssues": {
+    "sequenceIssues": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["residue", "position"],
+        "required": ["symbol", "position", "kind", "code", "message"],
         "properties": {
-          "residue": { "type": "string", "minLength": 1, "maxLength": 1 },
-          "position": { "type": "integer", "minimum": 1 }
+          "symbol": { "type": "string", "minLength": 1, "maxLength": 1 },
+          "position": { "type": "integer", "minimum": 1 },
+          "kind": { "enum": ["protein", "dna", "rna"] },
+          "code": { "enum": ["ambiguous_symbol", "invalid_symbol"] },
+          "message": { "type": "string", "minLength": 1 }
         },
         "additionalProperties": false
       }


### PR DESCRIPTION
## Summary
- add kind-aware FASTA validation APIs with explicit or auto kind selection
- add `biors fasta validate --kind <auto|protein|dna|rna>`
- update FASTA validation schema for kind counts and typed sequence issues
- prepare workspace metadata for v0.14.0

## Verification
- cargo test --locked -p biors-core
- cargo test --locked -p biors --test cli fasta_validate
- cargo test --locked -p biors --test schema_contract cli_outputs_match_declared_payload_schemas
- scripts/check-fast.sh
- scripts/check.sh
