### PR TITLE
feat(cli): add sequence validation command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "biors"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "biors-core",
  "clap",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "biors-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bio-rs/bio-rs"
-version = "0.14.0"
+version = "0.15.0"
 
 [workspace.dependencies]
-biors-core = { version = "0.14.0", path = "packages/rust/biors-core" }
+biors-core = { version = "0.15.0", path = "packages/rust/biors-core" }
 clap = { version = "4.5.37", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The goal is to make the input layer around bio-AI models faster, more portable, 
 Install the published CLI:
 
 ```bash
-cargo install biors --version 0.14.0
+cargo install biors --version 0.15.0
 biors --version
 ```
 
@@ -300,6 +300,7 @@ Public contract docs:
 
 Delivered:
 
+- `0.15.0`: biological sequence UX polish with `biors seq validate`, auto-detect-by-default validation, kind-specific messages, and refreshed docs
 - `0.14.0`: multi-alphabet FASTA validation with per-record kind assignment, `--kind` CLI override, mixed-kind summaries, and updated FASTA validation schema
 - `0.13.0`: biors-core DNA/RNA validation draft with `SequenceKind`, IUPAC nucleotide policies, auto-detection, and diagnostic sequence issues
 - `0.12.8`: biors-core SRP refactor for package, sequence, verification, and FASTA scanner internals with public API docs refreshed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 bio-rs turns biological sequences into validated, model-ready inputs for bio-AI workflows.
 
 ```txt
-FASTA -> validated protein sequence -> token ids -> model-ready JSON
+FASTA -> validated protein/DNA/RNA sequence -> protein token ids -> model-ready JSON
 ```
 
 > Status: pre-1.0 CLI and JSON contract stabilization.
@@ -61,6 +61,12 @@ Validate FASTA:
 
 ```bash
 biors fasta validate examples/protein.fasta
+```
+
+Validate mixed biological FASTA with per-record kind detection:
+
+```bash
+biors seq validate examples/protein.fasta
 ```
 
 Verify package fixture outputs:

--- a/docs/api-review.md
+++ b/docs/api-review.md
@@ -1,6 +1,6 @@
 # API and Schema Review
 
-This document records the 0.12.x review state for the 1.0 release-candidate
+This document records the pre-1.0 review state for the 1.0 release-candidate
 path. It is not a promise that every listed surface is stable today.
 
 ## Rust API
@@ -8,7 +8,7 @@ path. It is not a promise that every listed surface is stable today.
 Current candidate surfaces are listed in
 [`public-contract-1.0-candidates.md`](public-contract-1.0-candidates.md).
 
-Reviewed through 0.14.0:
+Reviewed through 0.15.0:
 
 - FASTA parse and reader APIs keep line and record-index diagnostics.
 - Tokenization preserves sequence length with explicit unknown-token IDs.
@@ -17,6 +17,8 @@ Reviewed through 0.14.0:
   sequence diagnostics.
 - FASTA validation can assign sequence kind per record with auto-detection or an
   explicit override while preserving the buffered reader hash path.
+- `biors seq validate` exposes the auto-detect-by-default biological sequence
+  validation UX while `biors fasta validate` keeps protein-first compatibility.
 - Protein-20 vocabulary can be borrowed through `protein_20_vocabulary` and
   `ProteinTokenizer::vocabulary_ref` without changing the owned vocabulary API.
 - FASTA inspect summaries can be produced from reader input without
@@ -36,14 +38,16 @@ Reviewed through 0.14.0:
 Schemas under [`../schemas`](../schemas) are validated by
 `packages/rust/biors/tests/schema_contract.rs`.
 
-Reviewed through 0.14.0:
+Reviewed through 0.15.0:
 
 - CLI success and error envelopes.
 - FASTA validation, inspect, tokenize, and model-input payloads.
 - FASTA validation schema includes per-record `kind`, `alphabet`, `kind_counts`,
   and typed sequence issue objects.
+- `biors seq validate` uses the FASTA validation payload schema.
 - Package manifest, inspect, validate, bridge, and verify payloads.
-- 0.12.8 changed internal module boundaries only; no JSON schema shape changed.
+- 0.15.0 keeps the JSON envelope shape unchanged while sharing the FASTA
+  validation schema across `fasta validate` and `seq validate`.
 
 ## Breaking-Change Cleanup
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -9,6 +9,7 @@ This document records the current pre-1.0 CLI and JSON contract surface.
 - `biors inspect <path|->`
 - `biors model-input --max-length <usize> [--pad-token-id <u8>] [--padding fixed_length|no_padding] <path|->`
 - `biors fasta validate [--kind protein|dna|rna|auto] <path|->`
+- `biors seq validate [--kind auto|protein|dna|rna] <path|->`
 - `biors package inspect <manifest>`
 - `biors package validate <manifest|->`
 - `biors package bridge <manifest>`
@@ -24,6 +25,8 @@ FASTA validation defaults to the protein policy for pre-0.14 compatibility.
 Passing `--kind dna`, `--kind rna`, or `--kind protein` applies one policy to
 all records; `--kind auto` assigns `protein`, `dna`, or `rna` per record and
 defaults ambiguous nucleotide-only ties such as `ACGN` to DNA.
+`seq validate` uses the same output contract but defaults to `--kind auto` for
+mixed biological sequence batches.
 FASTA-backed CLI commands read through buffered reader APIs and compute the legacy `fnv1a64:` input hash during the same pass.
 `inspect` uses a summary-only reader path and does not materialize token vectors
 when it only needs record, residue, warning, and error counts.

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -9,6 +9,14 @@ Error codes are stable identifiers for CLI JSON error mode.
 - `fasta.missing_header`: non-empty FASTA input did not start with `>`
 - `fasta.missing_sequence`: a FASTA record header had no sequence body
 
+## Sequence Validation
+
+Sequence validation warnings and errors are reported inside successful FASTA or
+`seq validate` payloads, not as top-level CLI failures.
+
+- `ambiguous_symbol`: a supported ambiguous IUPAC symbol was accepted with a warning
+- `invalid_symbol`: a symbol is not supported by the selected Protein, DNA, or RNA policy
+
 ## JSON
 
 - `json.invalid`: JSON input could not be decoded
@@ -46,6 +54,7 @@ parsing the human-readable `issue` field.
 ## Taxonomy
 
 - `fasta.*`: sequence file envelope and record parsing errors
+- sequence issue codes: per-record biological sequence validation diagnostics
 - `json.*`: machine-readable input or output failures
 - `io.*`: local filesystem or stdin failures
 - `package.*`: portable package contract, runtime, or fixture failures

--- a/docs/professional-readiness.md
+++ b/docs/professional-readiness.md
@@ -42,6 +42,14 @@ not as a model inference engine or broad bioinformatics suite.
 | 0.11.0 | benchmark and reproducibility pass, Biopython comparison, speed/memory proof assets | Implemented with reproducible benchmark JSON/Markdown and artifact validation. |
 | 0.12.0 | documentation and 1.0 release candidate, full workflow e2e, policies, release notes | Implemented with e2e CLI workflow tests, quickstart, API/schema review, MSRV, citation, and README release history. |
 
+## Phase 3 Coverage
+
+| Version | Planned area | Current status |
+|---|---|---|
+| 0.13.0 | DNA/RNA validation draft, sequence kind enum, unified alphabet policy | Implemented with `SequenceKind`, DNA/RNA IUPAC policies, auto-detection, and stable sequence diagnostics. |
+| 0.14.0 | multi-alphabet FASTA support, per-record kind assignment, `--kind` CLI flag | Implemented with kind-aware FASTA reader validation, mixed-kind summaries, schema coverage, and explicit override support. |
+| 0.15.0 | biological sequence UX polish, `seq validate`, kind-specific messages | Implemented with `biors seq validate`, auto-detect-by-default validation, kind-specific issue messages, and e2e coverage. |
+
 ## Refactor And Performance Review
 
 - FASTA parsing now uses a shared scanner for string and reader paths, reducing
@@ -70,9 +78,9 @@ not as a model inference engine or broad bioinformatics suite.
 
 ## Known Limits
 
-- Only protein FASTA and the `protein-20` tokenizer are supported.
-- Non-protein alphabets, nucleotide workflows, structure tooling, chemistry
-  tooling, and Python bindings are not implemented.
+- Protein, DNA, and RNA FASTA validation are supported; tokenization and
+  model-ready input remain protein-only through the `protein-20` tokenizer.
+- Structure tooling, chemistry tooling, and Python bindings are not implemented.
 - Package verification compares local artifacts; bio-rs does not run model
   inference backends.
 - Benchmark claims are limited to the committed FASTA validation/tokenization

--- a/docs/public-contract-1.0-candidates.md
+++ b/docs/public-contract-1.0-candidates.md
@@ -7,8 +7,13 @@ The following surfaces are candidates for stabilization before the first stable 
 - `parse_fasta_records`
 - `parse_fasta_records_reader`
 - `validate_fasta_input`
+- `validate_fasta_input_with_kind`
 - `validate_fasta_reader`
 - `validate_fasta_reader_with_hash`
+- `validate_fasta_reader_with_kind`
+- `validate_fasta_reader_with_kind_and_hash`
+- `SequenceKind`, `SequenceKindSelection`, `AlphabetPolicy`
+- `KindAwareSequenceValidationReport`, `ValidatedSequenceRecord`, `SequenceValidationIssue`
 - `tokenize_fasta_records`
 - `tokenize_fasta_records_reader`
 - `load_vocab_json`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ fresh checkout.
 ## Install
 
 ```bash
-cargo install biors --version 0.14.0
+cargo install biors --version 0.15.0
 biors --version
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,8 +19,19 @@ When working inside a source checkout, replace `biors` with
 biors fasta validate examples/protein.fasta
 ```
 
-Use this first when you need structured diagnostics for record counts,
-ambiguous residues, and invalid residues.
+Use this for protein-first FASTA validation. It defaults to the `protein-20`
+policy for compatibility and accepts `--kind protein|dna|rna|auto` when you
+want a specific policy.
+
+## Validate Biological Sequences
+
+```bash
+biors seq validate examples/protein.fasta
+```
+
+Use this for mixed biological FASTA. It defaults to `--kind auto`, assigns
+Protein, DNA, or RNA per record, and reports `kind_counts` plus kind-specific
+warnings and errors.
 
 ## Tokenize FASTA
 

--- a/packages/rust/biors/src/commands.rs
+++ b/packages/rust/biors/src/commands.rs
@@ -44,6 +44,10 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: PackageCommand,
     },
+    Seq {
+        #[command(subcommand)]
+        command: SeqCommand,
+    },
     Tokenize {
         path: PathBuf,
     },
@@ -53,6 +57,15 @@ pub(crate) enum Command {
 pub(crate) enum FastaCommand {
     Validate {
         #[arg(long, default_value_t = KindArg::Protein, value_enum)]
+        kind: KindArg,
+        path: PathBuf,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum SeqCommand {
+    Validate {
+        #[arg(long, default_value_t = KindArg::Auto, value_enum)]
         kind: KindArg,
         path: PathBuf,
     },
@@ -115,10 +128,7 @@ pub(crate) fn run(command: Command) -> Result<(), CliError> {
     match command {
         Command::Fasta { command } => match command {
             FastaCommand::Validate { kind, path } => {
-                let reader = open_fasta_input(&path)?;
-                let output = validate_fasta_reader_with_kind_and_hash(reader, kind.into())
-                    .map_err(|error| CliError::from_fasta_read(path, error))?;
-                print_success(Some(output.input_hash), output.report)?;
+                run_sequence_validation(path, kind)?;
             }
         },
         Command::Inspect { path } => {
@@ -214,6 +224,11 @@ pub(crate) fn run(command: Command) -> Result<(), CliError> {
                 print_success(None, report)?;
             }
         },
+        Command::Seq { command } => match command {
+            SeqCommand::Validate { kind, path } => {
+                run_sequence_validation(path, kind)?;
+            }
+        },
         Command::Tokenize { path } => {
             let reader = open_fasta_input(&path)?;
             let output = tokenize_fasta_records_reader(reader)
@@ -223,4 +238,11 @@ pub(crate) fn run(command: Command) -> Result<(), CliError> {
     }
 
     Ok(())
+}
+
+fn run_sequence_validation(path: PathBuf, kind: KindArg) -> Result<(), CliError> {
+    let reader = open_fasta_input(&path)?;
+    let output = validate_fasta_reader_with_kind_and_hash(reader, kind.into())
+        .map_err(|error| CliError::from_fasta_read(path, error))?;
+    print_success(Some(output.input_hash), output.report)
 }

--- a/packages/rust/biors/tests/cli.rs
+++ b/packages/rust/biors/tests/cli.rs
@@ -151,65 +151,6 @@ fn fasta_validate_outputs_validation_report() {
 }
 
 #[test]
-fn fasta_validate_kind_flag_outputs_kind_aware_report() {
-    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .arg("fasta")
-        .arg("validate")
-        .arg("--kind")
-        .arg("dna")
-        .arg("-")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn biors fasta validate")
-        .tap_stdin(">seq1\nACGNU\n");
-
-    assert!(output.status.success());
-    assert!(output.stderr.is_empty());
-
-    let value: Value = serde_json::from_slice(&output.stdout).expect("valid JSON output");
-    assert_eq!(value["data"]["kind_counts"]["dna"], 1);
-    assert_eq!(value["data"]["sequences"][0]["kind"], "dna");
-    assert_eq!(value["data"]["sequences"][0]["alphabet"], "dna-iupac");
-    assert_eq!(
-        value["data"]["sequences"][0]["warnings"][0]["code"],
-        "ambiguous_symbol"
-    );
-    assert_eq!(
-        value["data"]["sequences"][0]["errors"][0]["code"],
-        "invalid_symbol"
-    );
-}
-
-#[test]
-fn fasta_validate_auto_detects_mixed_sequence_kinds() {
-    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .arg("fasta")
-        .arg("validate")
-        .arg("--kind")
-        .arg("auto")
-        .arg("-")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn biors fasta validate")
-        .tap_stdin(">dna\nACGN\n>rna\nACGU\n>protein\nMEEPQSDPSV\n");
-
-    assert!(output.status.success());
-    assert!(output.stderr.is_empty());
-
-    let value: Value = serde_json::from_slice(&output.stdout).expect("valid JSON output");
-    assert_eq!(value["data"]["kind_counts"]["dna"], 1);
-    assert_eq!(value["data"]["kind_counts"]["rna"], 1);
-    assert_eq!(value["data"]["kind_counts"]["protein"], 1);
-    assert_eq!(value["data"]["sequences"][0]["kind"], "dna");
-    assert_eq!(value["data"]["sequences"][1]["kind"], "rna");
-    assert_eq!(value["data"]["sequences"][2]["kind"], "protein");
-}
-
-#[test]
 fn package_inspect_outputs_manifest_summary() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let manifest = manifest_dir.join("../../../examples/protein-package/manifest.json");

--- a/packages/rust/biors/tests/release_candidate.rs
+++ b/packages/rust/biors/tests/release_candidate.rs
@@ -14,6 +14,10 @@ fn full_workflow_e2e_covers_researcher_cli_path() {
     assert_eq!(validation["data"]["records"], 1);
     assert_eq!(validation["data"]["error_count"], 0);
 
+    let sequence_validation = run_biors(&["seq", "validate"], &[&fasta]);
+    assert_eq!(sequence_validation["data"]["records"], 1);
+    assert_eq!(sequence_validation["data"]["kind_counts"]["protein"], 1);
+
     let tokenized = run_biors(&["tokenize"], &[&fasta]);
     assert_eq!(tokenized["data"][0]["alphabet"], "protein-20");
     assert!(

--- a/packages/rust/biors/tests/schema_contract.rs
+++ b/packages/rust/biors/tests/schema_contract.rs
@@ -71,6 +71,9 @@ fn cli_outputs_match_declared_payload_schemas() {
     let fasta_validate = run_with_stdin(["fasta", "validate", "-"], ">seq1\nAX*\n");
     assert_payload_matches_schema(&fasta_validate, "schemas/fasta-validation-output.v0.json");
 
+    let seq_validate = run_with_stdin(["seq", "validate", "-"], ">seq1\nACGN\n");
+    assert_payload_matches_schema(&seq_validate, "schemas/fasta-validation-output.v0.json");
+
     let model_input = run_with_stdin(["model-input", "--max-length", "4", "-"], ">seq1\nACDEFG\n");
     assert_payload_matches_schema(&model_input, "schemas/model-input-output.v0.json");
 

--- a/packages/rust/biors/tests/sequence_cli.rs
+++ b/packages/rust/biors/tests/sequence_cli.rs
@@ -1,0 +1,96 @@
+use serde_json::Value;
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+#[test]
+fn fasta_validate_kind_flag_outputs_kind_aware_report() {
+    let output = run_with_stdin(
+        ["fasta", "validate", "--kind", "dna", "-"],
+        ">seq1\nACGNU\n",
+    );
+
+    let value: Value = serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(value["data"]["kind_counts"]["dna"], 1);
+    assert_eq!(value["data"]["sequences"][0]["kind"], "dna");
+    assert_eq!(value["data"]["sequences"][0]["alphabet"], "dna-iupac");
+    assert_eq!(
+        value["data"]["sequences"][0]["warnings"][0]["code"],
+        "ambiguous_symbol"
+    );
+    assert_eq!(
+        value["data"]["sequences"][0]["errors"][0]["code"],
+        "invalid_symbol"
+    );
+}
+
+#[test]
+fn fasta_validate_auto_detects_mixed_sequence_kinds() {
+    let output = run_with_stdin(
+        ["fasta", "validate", "--kind", "auto", "-"],
+        ">dna\nACGN\n>rna\nACGU\n>protein\nMEEPQSDPSV\n",
+    );
+
+    assert_mixed_kind_counts(&output);
+}
+
+#[test]
+fn seq_validate_defaults_to_auto_detected_sequence_kinds() {
+    let output = run_with_stdin(
+        ["seq", "validate", "-"],
+        ">dna\nACGN\n>rna\nACGU\n>protein\nMEEPQSDPSV\n",
+    );
+
+    assert_mixed_kind_counts(&output);
+}
+
+#[test]
+fn seq_validate_kind_override_uses_kind_specific_messages() {
+    let output = run_with_stdin(
+        ["seq", "validate", "--kind", "rna", "-"],
+        ">dna-looking\nACGT\n",
+    );
+
+    let value: Value = serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(value["data"]["sequences"][0]["kind"], "rna");
+    assert_eq!(value["data"]["sequences"][0]["errors"][0]["symbol"], "T");
+    assert!(value["data"]["sequences"][0]["errors"][0]["message"]
+        .as_str()
+        .expect("message")
+        .contains("RNA"));
+}
+
+fn run_with_stdin<const N: usize>(args: [&str; N], input: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_biors"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn biors");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(input.as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for biors");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    output
+}
+
+fn assert_mixed_kind_counts(output: &Output) {
+    let value: Value = serde_json::from_slice(&output.stdout).expect("valid JSON output");
+    assert_eq!(value["data"]["kind_counts"]["dna"], 1);
+    assert_eq!(value["data"]["kind_counts"]["rna"], 1);
+    assert_eq!(value["data"]["kind_counts"]["protein"], 1);
+    assert_eq!(value["data"]["sequences"][0]["kind"], "dna");
+    assert_eq!(value["data"]["sequences"][1]["kind"], "rna");
+    assert_eq!(value["data"]["sequences"][2]["kind"], "protein");
+}


### PR DESCRIPTION
## Summary
- add `biors seq validate` with auto-detect-by-default biological sequence validation
- keep `biors fasta validate` protein-first while sharing the same validation output
- move Phase 3 CLI tests into a focused integration test file
- refresh quickstart, CLI, error-code, readiness, and API review docs
- prepare workspace metadata for v0.15.0

## Verification
- cargo test --locked -p biors --test sequence_cli
- cargo test --locked -p biors --test schema_contract cli_outputs_match_declared_payload_schemas
- RUSTDOCFLAGS="-D warnings" cargo doc --locked -p biors-core --no-deps
- scripts/check-fast.sh
- scripts/check.sh
