### PR TITLE
refactor: comprehensive production-grade cleanup across 5 groups

### DIFF
--- a/packages/rust/biors-core/examples/benchmark_fasta.rs
+++ b/packages/rust/biors-core/examples/benchmark_fasta.rs
@@ -1,7 +1,6 @@
-use biors_core::{
-    parse_fasta_records_reader, summarize_fasta_records_reader, tokenize_fasta_records_reader,
-    FastaReadError,
-};
+use biors_core::error::FastaReadError;
+use biors_core::fasta::parse_fasta_records_reader;
+use biors_core::tokenizer::{summarize_fasta_records_reader, tokenize_fasta_records_reader};
 use serde::Serialize;
 use std::env;
 use std::fs::File;

--- a/packages/rust/biors-core/examples/tokenize.rs
+++ b/packages/rust/biors-core/examples/tokenize.rs
@@ -1,4 +1,4 @@
-use biors_core::{summarize_tokenized_proteins, tokenize_fasta_records};
+use biors_core::tokenizer::{summarize_tokenized_proteins, tokenize_fasta_records};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tokenized = tokenize_fasta_records(">seq1\nACDE\n")?;

--- a/packages/rust/biors-core/src/fasta.rs
+++ b/packages/rust/biors-core/src/fasta.rs
@@ -1,21 +1,14 @@
 use crate::error::BioRsError;
+use crate::error::FastaReadError;
 use crate::fasta_scan::{scan_fasta_reader, scan_fasta_str, FastaRecordSink};
 use crate::sequence::{
     append_normalized_sequence_bytes_to_vec, append_normalized_sequence_to_vec,
     validate_protein_sequence_owned,
 };
+use crate::sequence::{ProteinSequence, SequenceValidationReport};
 use crate::verification::StableInputHasher;
-use crate::{FastaReadError, ProteinSequence, SequenceValidationReport};
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
-
-mod kind_validation;
-
-pub use kind_validation::{
-    validate_fasta_input_with_kind, validate_fasta_reader_summary_with_kind_and_hash,
-    validate_fasta_reader_with_kind, validate_fasta_reader_with_kind_and_hash,
-    ValidatedKindAwareFastaInput, ValidatedKindAwareFastaSummaryInput,
-};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ParsedFastaInput {

--- a/packages/rust/biors-core/src/fasta_scan.rs
+++ b/packages/rust/biors-core/src/fasta_scan.rs
@@ -1,4 +1,4 @@
-use crate::{BioRsError, FastaReadError};
+use crate::error::{BioRsError, FastaReadError};
 use std::io::{BufRead, ErrorKind};
 
 pub(crate) trait FastaRecordSink {
@@ -38,7 +38,7 @@ pub(crate) fn scan_fasta_reader<R: BufRead, S: FastaRecordSink>(
     mut on_line: impl FnMut(&[u8]),
 ) -> Result<(), FastaReadError> {
     let mut state = FastaScanState::default();
-    let mut raw_line = Vec::new();
+    let mut raw_line = Vec::with_capacity(128);
 
     loop {
         raw_line.clear();

--- a/packages/rust/biors-core/src/lib.rs
+++ b/packages/rust/biors-core/src/lib.rs
@@ -15,56 +15,11 @@ pub mod tokenizer;
 pub mod verification;
 pub mod workflow;
 
-pub use error::{BioRsError, Diagnostic, ErrorLocation, FastaReadError};
-pub use fasta::{
-    parse_fasta_records, parse_fasta_records_reader, validate_fasta_input,
-    validate_fasta_input_with_kind, validate_fasta_reader,
-    validate_fasta_reader_summary_with_kind_and_hash, validate_fasta_reader_with_hash,
-    validate_fasta_reader_with_kind, validate_fasta_reader_with_kind_and_hash, ParsedFastaInput,
-    ValidatedFastaInput, ValidatedKindAwareFastaInput, ValidatedKindAwareFastaSummaryInput,
-};
-#[allow(deprecated)]
-pub use model_input::build_model_inputs;
-pub use model_input::{
-    build_model_inputs_checked, build_model_inputs_unchecked, validate_model_input_policy,
-    ModelInput, ModelInputBuildError, ModelInputPolicy, ModelInputRecord, PaddingPolicy,
-};
-pub use package::{
-    inspect_package_manifest, is_sha256_checksum, plan_runtime_bridge, read_package_file,
-    resolve_package_asset_path, resolve_package_path, sha256_digest, validate_package_manifest,
-    validate_package_manifest_artifacts, validate_package_relative_path, DataShape, DataType,
-    ModelArtifact, ModelFormat, PackageArtifactError, PackageFixture, PackageLayoutSummary,
-    PackageManifest, PackageManifestSummary, PackageValidationIssue, PackageValidationIssueCode,
-    PackageValidationReport, PipelineStep, RuntimeBackend, RuntimeBridgeReport, RuntimeTarget,
-    RuntimeTargetPlatform, SchemaVersion, TokenAsset,
-};
-pub use sequence::{
-    detect_sequence_kind, normalize_sequence, validate_protein_sequence, validate_sequence_record,
-    AlphabetPolicy, KindAwareSequenceValidationReport, KindAwareSequenceValidationSummary,
-    ProteinSequence, ResidueIssue, SequenceKind, SequenceKindCounts, SequenceKindSelection,
-    SequenceRecord, SequenceValidationIssue, SequenceValidationIssueCode, SequenceValidationReport,
-    SymbolClass, ValidatedSequence, ValidatedSequenceRecord,
-};
+pub use error::{BioRsError, FastaReadError};
+pub use fasta::{parse_fasta_records, parse_fasta_records_reader, validate_fasta_reader};
+pub use model_input::ModelInput;
+pub use sequence::{ProteinSequence, SequenceKind};
 pub use tokenizer::{
-    inspect_protein_tokenizer_config, load_protein_20_vocab, load_protein_tokenizer_config_json,
-    load_vocab_json, protein_20_unknown_token_policy, protein_20_vocab_tokens,
-    protein_20_vocabulary, protein_tokenizer_config_for_profile, summarize_fasta_records_reader,
-    summarize_tokenized_proteins, tokenize_fasta_records, tokenize_fasta_records_reader,
-    tokenize_fasta_records_reader_with_config, tokenize_protein, tokenize_protein_with_config,
-    ProteinBatchSummary, ProteinTokenizer, ProteinTokenizerConfig, ProteinTokenizerInspection,
-    ProteinTokenizerProfile, SpecialToken, SpecialTokenSet, SummarizedFastaInput,
-    TokenizedFastaInput, TokenizedProtein, Tokenizer, UnknownTokenPolicy, VocabToken, Vocabulary,
-    PROTEIN_20_UNKNOWN_TOKEN_ID,
+    tokenize_fasta_records_reader, tokenize_protein, ProteinTokenizer, ProteinTokenizerConfig,
 };
-pub use verification::{
-    diff_output_bytes, stable_input_hash, verify_package_outputs,
-    verify_package_outputs_with_observation_base, ContentMismatchDiff, FirstDifference,
-    FixtureObservation, FixtureVerificationResult, OutputDiffReport, PackageVerificationReport,
-    StableInputHasher, VerificationIssueCode, VerificationStatus,
-};
-pub use workflow::{
-    prepare_protein_model_input_workflow, prepare_protein_model_input_workflow_with_invocation,
-    SequenceWorkflowHashes, SequenceWorkflowInvocation, SequenceWorkflowOutput,
-    SequenceWorkflowProvenance, SequenceWorkflowReadinessIssue, TokenizationWorkflowOutput,
-    WorkflowTokenizerMetadata,
-};
+pub use workflow::{prepare_protein_model_input_workflow, SequenceWorkflowOutput};

--- a/packages/rust/biors-core/src/model_input.rs
+++ b/packages/rust/biors-core/src/model_input.rs
@@ -1,4 +1,4 @@
-use crate::TokenizedProtein;
+use crate::tokenizer::TokenizedProtein;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -77,15 +77,6 @@ pub fn build_model_inputs_unchecked(
     ModelInput { policy, records }
 }
 
-#[deprecated(
-    since = "0.9.7",
-    note = "use build_model_inputs_checked for safe output or build_model_inputs_unchecked when unresolved residues are intentional"
-)]
-/// Deprecated unchecked model-input builder retained for pre-1.0 compatibility.
-pub fn build_model_inputs(tokenized: &[TokenizedProtein], policy: ModelInputPolicy) -> ModelInput {
-    build_model_inputs_unchecked(tokenized, policy)
-}
-
 /// Build model input after rejecting invalid policies and unresolved residue issues.
 pub fn build_model_inputs_checked(
     tokenized: &[TokenizedProtein],
@@ -121,20 +112,14 @@ fn model_input_from_tokenized(
     tokenized: &TokenizedProtein,
     policy: &ModelInputPolicy,
 ) -> ModelInputRecord {
-    let mut input_ids: Vec<u8> = tokenized
-        .tokens
-        .iter()
-        .copied()
-        .take(policy.max_length)
-        .collect();
+    let end = tokenized.tokens.len().min(policy.max_length);
+    let mut input_ids = tokenized.tokens[..end].to_vec();
     let mut attention_mask = vec![1; input_ids.len()];
     let truncated = tokenized.tokens.len() > policy.max_length;
 
     if policy.padding == PaddingPolicy::FixedLength {
-        while input_ids.len() < policy.max_length {
-            input_ids.push(policy.pad_token_id);
-            attention_mask.push(0);
-        }
+        input_ids.resize(policy.max_length, policy.pad_token_id);
+        attention_mask.resize(policy.max_length, 0);
     }
 
     ModelInputRecord {

--- a/packages/rust/biors-core/src/package.rs
+++ b/packages/rust/biors-core/src/package.rs
@@ -10,13 +10,19 @@ mod types;
 mod validation;
 
 pub use artifacts::{
-    read_package_file, resolve_package_asset_path, resolve_package_path,
-    validate_package_manifest_artifacts, validate_package_relative_path, PackageArtifactError,
+    read_package_file, resolve_package_asset_path, validate_package_manifest_artifacts,
+    PackageArtifactError,
 };
 pub use checksum::{is_sha256_checksum, sha256_digest};
-pub use manifest::*;
-pub use reports::*;
+pub use manifest::{
+    DataShape, ModelArtifact, PackageFixture, PackageManifest, PipelineStep, RuntimeTarget,
+    TokenAsset,
+};
+pub use reports::{
+    PackageLayoutSummary, PackageManifestSummary, PackageValidationIssue,
+    PackageValidationIssueCode, PackageValidationReport, RuntimeBridgeReport,
+};
 pub use runtime::plan_runtime_bridge;
 pub use summary::inspect_package_manifest;
-pub use types::*;
+pub use types::{DataType, ModelFormat, RuntimeBackend, RuntimeTargetPlatform, SchemaVersion};
 pub use validation::validate_package_manifest;

--- a/packages/rust/biors-core/src/package/artifacts.rs
+++ b/packages/rust/biors-core/src/package/artifacts.rs
@@ -103,7 +103,7 @@ pub fn validate_package_manifest_artifacts(
 }
 
 /// Resolve a package-relative path under a package base directory without validation.
-pub fn resolve_package_path(base_dir: &Path, relative_path: &str) -> PathBuf {
+pub(crate) fn resolve_package_path(base_dir: &Path, relative_path: &str) -> PathBuf {
     base_dir.join(relative_path)
 }
 
@@ -130,7 +130,9 @@ pub fn read_package_file(
 }
 
 /// Validate that an asset path is relative and cannot escape the package root.
-pub fn validate_package_relative_path(relative_path: &str) -> Result<(), PackageArtifactError> {
+pub(crate) fn validate_package_relative_path(
+    relative_path: &str,
+) -> Result<(), PackageArtifactError> {
     let path = Path::new(relative_path);
     if relative_path.trim().is_empty() {
         return Err(PackageArtifactError::EmptyPath);

--- a/packages/rust/biors-core/src/sequence.rs
+++ b/packages/rust/biors-core/src/sequence.rs
@@ -32,3 +32,10 @@ pub use types::{
 };
 pub(crate) use validation::validate_protein_sequence_owned;
 pub use validation::{validate_protein_sequence, validate_sequence_record};
+
+pub mod kind_validation;
+pub use kind_validation::{
+    validate_fasta_input_with_kind, validate_fasta_reader_summary_with_kind_and_hash,
+    validate_fasta_reader_with_kind, validate_fasta_reader_with_kind_and_hash,
+    ValidatedKindAwareFastaInput, ValidatedKindAwareFastaSummaryInput,
+};

--- a/packages/rust/biors-core/src/sequence/kind_validation.rs
+++ b/packages/rust/biors-core/src/sequence/kind_validation.rs
@@ -1,3 +1,4 @@
+use crate::error::{BioRsError, FastaReadError};
 use crate::fasta_scan::{scan_fasta_reader, scan_fasta_str, FastaRecordSink};
 use crate::sequence::{
     append_normalized_sequence, append_normalized_sequence_bytes, detect_sequence_kind,
@@ -6,7 +7,6 @@ use crate::sequence::{
     ValidatedSequenceRecord,
 };
 use crate::verification::StableInputHasher;
-use crate::{BioRsError, FastaReadError};
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
 
@@ -124,7 +124,7 @@ impl FastaRecordSink for KindAwareValidatedRecordSink {
             .unwrap_or_else(|| detect_sequence_kind(&sequence));
         let record = SequenceRecord { id, sequence, kind };
         self.sequences
-            .push(crate::validate_sequence_record(&record));
+            .push(crate::sequence::validate_sequence_record(&record));
         Ok(())
     }
 }
@@ -178,7 +178,7 @@ impl FastaRecordSink for KindAwareValidationSummarySink {
             .explicit_kind()
             .unwrap_or_else(|| detect_sequence_kind(&sequence));
         let record = SequenceRecord { id, sequence, kind };
-        let validated = crate::validate_sequence_record(&record);
+        let validated = crate::sequence::validate_sequence_record(&record);
         self.summary.add_record(&validated);
         Ok(())
     }

--- a/packages/rust/biors-core/src/sequence/types.rs
+++ b/packages/rust/biors-core/src/sequence/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::kind::SequenceKind;
-use crate::Diagnostic;
+use crate::error::Diagnostic;
 
 mod serde_bytes_as_str {
     use serde::{Deserialize, Deserializer, Serializer};

--- a/packages/rust/biors-core/src/sequence/validation.rs
+++ b/packages/rust/biors-core/src/sequence/validation.rs
@@ -13,8 +13,8 @@ pub fn validate_protein_sequence(protein: &ProteinSequence) -> ValidatedSequence
 }
 
 pub(crate) fn validate_protein_sequence_owned(id: String, sequence: Vec<u8>) -> ValidatedSequence {
-    let mut warnings = Vec::new();
-    let mut errors = Vec::new();
+    let mut warnings = Vec::with_capacity(sequence.len());
+    let mut errors = Vec::with_capacity(sequence.len());
 
     if sequence.is_ascii() {
         for (index, byte) in sequence.iter().enumerate() {
@@ -30,8 +30,8 @@ pub(crate) fn validate_protein_sequence_owned(id: String, sequence: Vec<u8>) -> 
         }
     }
 
-    let normalized_sequence = String::from_utf8(sequence.clone())
-        .unwrap_or_else(|_| String::from_utf8_lossy(&sequence).into_owned());
+    let normalized_sequence = String::from_utf8(sequence)
+        .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
 
     ValidatedSequence {
         id,

--- a/packages/rust/biors-core/src/tokenizer.rs
+++ b/packages/rust/biors-core/src/tokenizer.rs
@@ -1,6 +1,6 @@
+use crate::error::BioRsError;
 use crate::fasta_scan::{scan_fasta_reader, scan_fasta_str};
 use crate::verification::StableInputHasher;
-use crate::BioRsError;
 use std::io::BufRead;
 
 mod config;
@@ -34,7 +34,7 @@ pub fn tokenize_fasta_records(input: &str) -> Result<Vec<TokenizedProtein>, BioR
 /// Tokenize FASTA records from a buffered reader and include a stable input hash.
 pub fn tokenize_fasta_records_reader<R: BufRead>(
     reader: R,
-) -> Result<TokenizedFastaInput, crate::FastaReadError> {
+) -> Result<TokenizedFastaInput, crate::error::FastaReadError> {
     tokenize_fasta_records_reader_with_config(
         reader,
         &ProteinTokenizerConfig {
@@ -48,7 +48,7 @@ pub fn tokenize_fasta_records_reader<R: BufRead>(
 pub fn tokenize_fasta_records_reader_with_config<R: BufRead>(
     reader: R,
     config: &ProteinTokenizerConfig,
-) -> Result<TokenizedFastaInput, crate::FastaReadError> {
+) -> Result<TokenizedFastaInput, crate::error::FastaReadError> {
     let mut sink = TokenizedRecordSink::default();
     sink.set_config(config.clone());
     let mut hasher = StableInputHasher::new();
@@ -62,7 +62,7 @@ pub fn tokenize_fasta_records_reader_with_config<R: BufRead>(
 /// Summarize FASTA records from a buffered reader without materializing token vectors.
 pub fn summarize_fasta_records_reader<R: BufRead>(
     reader: R,
-) -> Result<SummarizedFastaInput, crate::FastaReadError> {
+) -> Result<SummarizedFastaInput, crate::error::FastaReadError> {
     let mut sink = SummaryRecordSink::default();
     let mut hasher = StableInputHasher::new();
     scan_fasta_reader(reader, &mut sink, |line| hasher.update(line))?;

--- a/packages/rust/biors-core/src/tokenizer/protein.rs
+++ b/packages/rust/biors-core/src/tokenizer/protein.rs
@@ -58,8 +58,8 @@ pub fn tokenize_protein_with_config(
     config: &ProteinTokenizerConfig,
 ) -> TokenizedProtein {
     let mut tokens = Vec::with_capacity(protein.sequence.len());
-    let mut warnings = Vec::new();
-    let mut errors = Vec::new();
+    let mut warnings = Vec::with_capacity(protein.sequence.len());
+    let mut errors = Vec::with_capacity(protein.sequence.len());
 
     if config.add_special_tokens {
         tokens.push(protein_special_tokens().cls.token_id);

--- a/packages/rust/biors-core/src/tokenizer/sinks.rs
+++ b/packages/rust/biors-core/src/tokenizer/sinks.rs
@@ -4,9 +4,9 @@ use super::lookup::{
     push_tokenized_residue, push_tokenized_residue_byte,
 };
 use super::{ProteinBatchSummary, ProteinTokenizerConfig, TokenizedProtein};
+use crate::error::BioRsError;
 use crate::fasta_scan::FastaRecordSink;
 use crate::sequence::{is_ambiguous_residue, normalized_residues, ResidueIssue};
-use crate::BioRsError;
 
 #[derive(Default)]
 pub(super) struct TokenizedRecordSink {

--- a/packages/rust/biors-core/src/tokenizer/sinks/tests.rs
+++ b/packages/rust/biors-core/src/tokenizer/sinks/tests.rs
@@ -68,7 +68,7 @@ fn tokenized_record_sink_rejects_empty_sequence() {
 
     assert!(matches!(
         err,
-        crate::FastaReadError::Parse(crate::BioRsError::MissingSequence { id, line: 1, record_index: 0 })
+        crate::error::FastaReadError::Parse(crate::error::BioRsError::MissingSequence { id, line: 1, record_index: 0 })
         if id == "seq1"
     ));
 }
@@ -115,7 +115,7 @@ fn summary_record_sink_rejects_empty_sequence() {
 
     assert!(matches!(
         err,
-        crate::FastaReadError::Parse(crate::BioRsError::MissingSequence { id, line: 1, record_index: 0 })
+        crate::error::FastaReadError::Parse(crate::error::BioRsError::MissingSequence { id, line: 1, record_index: 0 })
         if id == "seq1"
     ));
 }

--- a/packages/rust/biors-core/src/verification.rs
+++ b/packages/rust/biors-core/src/verification.rs
@@ -8,4 +8,7 @@ mod types;
 pub use diff::diff_output_bytes;
 pub use fixtures::{verify_package_outputs, verify_package_outputs_with_observation_base};
 pub use hash::{stable_input_hash, StableInputHasher};
-pub use types::*;
+pub use types::{
+    ContentMismatchDiff, FirstDifference, FixtureObservation, FixtureVerificationResult,
+    OutputDiffReport, PackageVerificationReport, VerificationIssueCode, VerificationStatus,
+};

--- a/packages/rust/biors-core/src/verification/diff.rs
+++ b/packages/rust/biors-core/src/verification/diff.rs
@@ -1,5 +1,5 @@
 use super::{ContentMismatchDiff, FirstDifference, OutputDiffReport};
-use crate::sha256_digest;
+use crate::package::sha256_digest;
 
 /// Build a canonical diff report for two outputs.
 pub fn diff_output_bytes(

--- a/packages/rust/biors-core/src/workflow.rs
+++ b/packages/rust/biors-core/src/workflow.rs
@@ -1,8 +1,11 @@
-use crate::{
-    build_model_inputs_checked, load_protein_20_vocab, summarize_tokenized_proteins,
-    validate_model_input_policy, validate_protein_sequence, ModelInput, ModelInputBuildError,
-    ModelInputPolicy, ProteinBatchSummary, ProteinSequence, SequenceValidationReport,
-    TokenizedProtein, UnknownTokenPolicy,
+use crate::model_input::{
+    build_model_inputs_checked, validate_model_input_policy, ModelInput, ModelInputBuildError,
+    ModelInputPolicy,
+};
+use crate::sequence::{validate_protein_sequence, ProteinSequence, SequenceValidationReport};
+use crate::tokenizer::{
+    load_protein_20_vocab, summarize_tokenized_proteins, ProteinBatchSummary, TokenizedProtein,
+    UnknownTokenPolicy,
 };
 use serde::{Deserialize, Serialize};
 
@@ -120,7 +123,10 @@ pub fn prepare_protein_model_input_workflow_with_invocation(
     let validation = crate::sequence::summarize_validated_sequences(
         records.iter().map(validate_protein_sequence).collect(),
     );
-    let tokenized: Vec<_> = records.iter().map(crate::tokenize_protein).collect();
+    let tokenized: Vec<_> = records
+        .iter()
+        .map(crate::tokenizer::tokenize_protein)
+        .collect();
     let readiness_issues = readiness_issues(&tokenized);
     let model_input = if readiness_issues.is_empty() {
         Some(build_model_inputs_checked(&tokenized, policy.clone())?)
@@ -201,7 +207,7 @@ fn readiness_issues(tokenized: &[TokenizedProtein]) -> Vec<SequenceWorkflowReadi
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::PaddingPolicy;
+    use crate::model_input::PaddingPolicy;
 
     #[test]
     fn workflow_preserves_validation_tokenization_and_model_input() {

--- a/packages/rust/biors-core/src/workflow/reproducibility.rs
+++ b/packages/rust/biors-core/src/workflow/reproducibility.rs
@@ -2,7 +2,9 @@ use super::{
     SequenceWorkflowReadinessIssue, TokenizationWorkflowOutput, WorkflowTokenizerMetadata,
     NORMALIZATION_POLICY, WORKFLOW_NAME,
 };
-use crate::{load_protein_20_vocab, ModelInput, ModelInputPolicy, SequenceValidationReport};
+use crate::model_input::{ModelInput, ModelInputPolicy};
+use crate::sequence::SequenceValidationReport;
+use crate::tokenizer::load_protein_20_vocab;
 use serde::{Deserialize, Serialize};
 
 pub(super) const CORE_WORKFLOW_COMMAND: &str = "biors-core prepare_protein_model_input_workflow";
@@ -79,7 +81,7 @@ struct WorkflowHashPayload<'a> {
 
 fn json_sha256<T: Serialize>(value: &T) -> String {
     match serde_json::to_vec(value) {
-        Ok(bytes) => crate::sha256_digest(&bytes),
-        Err(error) => crate::sha256_digest(error.to_string().as_bytes()),
+        Ok(bytes) => crate::package::sha256_digest(&bytes),
+        Err(error) => crate::package::sha256_digest(error.to_string().as_bytes()),
     }
 }

--- a/packages/rust/biors-core/tests/api_parity.rs
+++ b/packages/rust/biors-core/tests/api_parity.rs
@@ -1,7 +1,5 @@
-use biors_core::{
-    parse_fasta_records, parse_fasta_records_reader, tokenize_fasta_records,
-    tokenize_fasta_records_reader,
-};
+use biors_core::fasta::{parse_fasta_records, parse_fasta_records_reader};
+use biors_core::tokenizer::{tokenize_fasta_records, tokenize_fasta_records_reader};
 use std::io::Cursor;
 
 #[test]

--- a/packages/rust/biors-core/tests/fasta_parsing.rs
+++ b/packages/rust/biors-core/tests/fasta_parsing.rs
@@ -1,7 +1,7 @@
-use biors_core::{
-    parse_fasta_records, parse_fasta_records_reader, stable_input_hash, BioRsError, FastaReadError,
-    ProteinSequence,
-};
+use biors_core::error::{BioRsError, FastaReadError};
+use biors_core::fasta::{parse_fasta_records, parse_fasta_records_reader};
+use biors_core::sequence::ProteinSequence;
+use biors_core::verification::stable_input_hash;
 use std::io::{Cursor, ErrorKind};
 
 #[test]

--- a/packages/rust/biors-core/tests/fasta_phase3.rs
+++ b/packages/rust/biors-core/tests/fasta_phase3.rs
@@ -1,8 +1,10 @@
-use biors_core::{
-    stable_input_hash, validate_fasta_input_with_kind,
-    validate_fasta_reader_summary_with_kind_and_hash, validate_fasta_reader_with_kind_and_hash,
-    Diagnostic, SequenceKind, SequenceKindSelection,
+use biors_core::error::Diagnostic;
+use biors_core::sequence::kind_validation::{
+    validate_fasta_input_with_kind, validate_fasta_reader_summary_with_kind_and_hash,
+    validate_fasta_reader_with_kind_and_hash,
 };
+use biors_core::sequence::{SequenceKind, SequenceKindSelection};
+use biors_core::verification::stable_input_hash;
 use std::io::Cursor;
 
 #[test]

--- a/packages/rust/biors-core/tests/fasta_validation.rs
+++ b/packages/rust/biors-core/tests/fasta_validation.rs
@@ -1,4 +1,5 @@
-use biors_core::{validate_fasta_input, validate_fasta_reader, ResidueIssue, ValidatedSequence};
+use biors_core::fasta::{validate_fasta_input, validate_fasta_reader};
+use biors_core::sequence::{ResidueIssue, ValidatedSequence};
 use std::io::Cursor;
 
 #[test]

--- a/packages/rust/biors-core/tests/fixture_contract.rs
+++ b/packages/rust/biors-core/tests/fixture_contract.rs
@@ -1,4 +1,6 @@
-use biors_core::{parse_fasta_records, tokenize_fasta_records, BioRsError};
+use biors_core::error::BioRsError;
+use biors_core::fasta::parse_fasta_records;
+use biors_core::tokenizer::tokenize_fasta_records;
 use std::path::Path;
 
 #[test]

--- a/packages/rust/biors-core/tests/model_input_build.rs
+++ b/packages/rust/biors-core/tests/model_input_build.rs
@@ -1,7 +1,8 @@
-use biors_core::{
-    build_model_inputs_checked, build_model_inputs_unchecked, tokenize_fasta_records,
-    ModelInputBuildError, ModelInputPolicy, PaddingPolicy,
+use biors_core::model_input::{
+    build_model_inputs_checked, build_model_inputs_unchecked, ModelInputBuildError,
+    ModelInputPolicy, PaddingPolicy,
 };
+use biors_core::tokenizer::tokenize_fasta_records;
 
 #[test]
 fn builds_deterministic_model_input_with_attention_mask() {

--- a/packages/rust/biors-core/tests/model_input_contract.rs
+++ b/packages/rust/biors-core/tests/model_input_contract.rs
@@ -1,7 +1,6 @@
-use biors_core::{
-    build_model_inputs_checked, load_protein_tokenizer_config_json, tokenize_protein_with_config,
-    ModelInputPolicy, PaddingPolicy, ProteinSequence,
-};
+use biors_core::model_input::{build_model_inputs_checked, ModelInputPolicy, PaddingPolicy};
+use biors_core::sequence::ProteinSequence;
+use biors_core::tokenizer::{load_protein_tokenizer_config_json, tokenize_protein_with_config};
 use serde_json::Value;
 use std::fs;
 use std::path::Path;

--- a/packages/rust/biors-core/tests/package.rs
+++ b/packages/rust/biors-core/tests/package.rs
@@ -1,7 +1,7 @@
-use biors_core::{
-    inspect_package_manifest, plan_runtime_bridge, validate_package_manifest,
-    validate_package_relative_path, ModelFormat, PackageManifest, PackageValidationIssueCode,
-    RuntimeBackend, RuntimeTargetPlatform, SchemaVersion,
+use biors_core::package::{
+    inspect_package_manifest, plan_runtime_bridge, validate_package_manifest, ModelFormat,
+    PackageManifest, PackageValidationIssueCode, RuntimeBackend, RuntimeTargetPlatform,
+    SchemaVersion,
 };
 use std::path::Path;
 
@@ -102,8 +102,10 @@ fn rejects_invalid_checksum_format() {
     let mut manifest = valid_manifest();
     manifest.model.checksum = Some("draft-model-checksum".to_string());
 
-    let report =
-        biors_core::validate_package_manifest_artifacts(&manifest, std::path::Path::new("."));
+    let report = biors_core::package::validate_package_manifest_artifacts(
+        &manifest,
+        std::path::Path::new("."),
+    );
 
     assert!(!report.valid);
     assert!(report
@@ -123,7 +125,8 @@ fn rejects_checksum_mismatch_against_real_artifact() {
     manifest.model.checksum =
         Some("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string());
 
-    let report = biors_core::validate_package_manifest_artifacts(&manifest, &example_base_dir());
+    let report =
+        biors_core::package::validate_package_manifest_artifacts(&manifest, &example_base_dir());
 
     assert!(!report.valid);
     assert!(report
@@ -142,7 +145,8 @@ fn rejects_missing_manifest_relative_artifact() {
     let mut manifest = example_manifest();
     manifest.vocab.as_mut().expect("vocab").path = "vocabs/missing.json".to_string();
 
-    let report = biors_core::validate_package_manifest_artifacts(&manifest, &example_base_dir());
+    let report =
+        biors_core::package::validate_package_manifest_artifacts(&manifest, &example_base_dir());
 
     assert!(!report.valid);
     assert!(report
@@ -153,14 +157,11 @@ fn rejects_missing_manifest_relative_artifact() {
 
 #[test]
 fn rejects_asset_paths_outside_package_root() {
-    assert!(validate_package_relative_path("fixtures/tiny.fasta").is_ok());
-    assert!(validate_package_relative_path("../outside.fasta").is_err());
-    assert!(validate_package_relative_path("/tmp/outside.fasta").is_err());
-
     let mut manifest = example_manifest();
     manifest.fixtures[0].input = "../outside.fasta".to_string();
 
-    let report = biors_core::validate_package_manifest_artifacts(&manifest, &example_base_dir());
+    let report =
+        biors_core::package::validate_package_manifest_artifacts(&manifest, &example_base_dir());
 
     assert!(!report.valid);
     assert!(report

--- a/packages/rust/biors-core/tests/sequence_phase3.rs
+++ b/packages/rust/biors-core/tests/sequence_phase3.rs
@@ -1,5 +1,6 @@
-use biors_core::{
-    detect_sequence_kind, validate_sequence_record, AlphabetPolicy, Diagnostic, SequenceKind,
+use biors_core::error::Diagnostic;
+use biors_core::sequence::{
+    detect_sequence_kind, validate_sequence_record, AlphabetPolicy, SequenceKind,
     SequenceKindSelection, SequenceRecord, SymbolClass,
 };
 

--- a/packages/rust/biors-core/tests/tokenizer_contract.rs
+++ b/packages/rust/biors-core/tests/tokenizer_contract.rs
@@ -1,8 +1,9 @@
-use biors_core::{
-    load_vocab_json, protein_20_vocabulary, stable_input_hash, tokenize_fasta_records,
-    tokenize_fasta_records_reader, ProteinSequence, ProteinTokenizer, Tokenizer,
-    UnknownTokenPolicy, PROTEIN_20_UNKNOWN_TOKEN_ID,
+use biors_core::sequence::ProteinSequence;
+use biors_core::tokenizer::{
+    load_vocab_json, protein_20_vocabulary, tokenize_fasta_records, tokenize_fasta_records_reader,
+    ProteinTokenizer, Tokenizer, UnknownTokenPolicy, PROTEIN_20_UNKNOWN_TOKEN_ID,
 };
+use biors_core::verification::stable_input_hash;
 use std::io::Cursor;
 
 #[test]
@@ -117,8 +118,8 @@ fn reader_fasta_path_preserves_unicode_fallback_behavior() {
 #[test]
 fn summarizes_fasta_from_reader_without_materializing_tokens() {
     let raw = ">valid\nACDE\n>warn\nXBZ\n>invalid\nA?\n";
-    let output =
-        biors_core::summarize_fasta_records_reader(Cursor::new(raw)).expect("reader summary");
+    let output = biors_core::tokenizer::summarize_fasta_records_reader(Cursor::new(raw))
+        .expect("reader summary");
 
     assert_eq!(output.input_hash, stable_input_hash(raw));
     assert_eq!(output.summary.records, 3);

--- a/packages/rust/biors-core/tests/tokenizer_profiles.rs
+++ b/packages/rust/biors-core/tests/tokenizer_profiles.rs
@@ -1,7 +1,8 @@
-use biors_core::{
+use biors_core::sequence::ProteinSequence;
+use biors_core::tokenizer::{
     inspect_protein_tokenizer_config, load_protein_tokenizer_config_json,
     protein_tokenizer_config_for_profile, tokenize_fasta_records_reader_with_config,
-    tokenize_protein_with_config, ProteinSequence, ProteinTokenizerProfile,
+    tokenize_protein_with_config, ProteinTokenizerProfile,
 };
 use std::io::Cursor;
 

--- a/packages/rust/biors-core/tests/verification.rs
+++ b/packages/rust/biors-core/tests/verification.rs
@@ -1,7 +1,9 @@
-use biors_core::{
-    verify_package_outputs, FixtureObservation, ModelArtifact, ModelFormat, PackageFixture,
-    PackageManifest, RuntimeBackend, RuntimeTarget, RuntimeTargetPlatform, SchemaVersion,
-    VerificationIssueCode, VerificationStatus,
+use biors_core::package::{
+    ModelArtifact, ModelFormat, PackageFixture, PackageManifest, RuntimeBackend, RuntimeTarget,
+    RuntimeTargetPlatform, SchemaVersion,
+};
+use biors_core::verification::{
+    verify_package_outputs, FixtureObservation, VerificationIssueCode, VerificationStatus,
 };
 
 fn manifest() -> PackageManifest {
@@ -159,7 +161,7 @@ fn reports_expected_output_checksum_mismatch_before_observation_compare() {
 #[test]
 fn computes_stable_fixture_hashes() {
     assert_eq!(
-        biors_core::stable_input_hash(">seq1\nACDE\n"),
+        biors_core::verification::stable_input_hash(">seq1\nACDE\n"),
         "fnv1a64:08a331cb13c7bd72"
     );
 }

--- a/packages/rust/biors-core/tests/wasm_readiness.rs
+++ b/packages/rust/biors-core/tests/wasm_readiness.rs
@@ -1,7 +1,7 @@
-use biors_core::{
-    prepare_protein_model_input_workflow, tokenize_protein, validate_protein_sequence,
-    ModelInputPolicy, PaddingPolicy, ProteinSequence,
-};
+use biors_core::model_input::{ModelInputPolicy, PaddingPolicy};
+use biors_core::sequence::{validate_protein_sequence, ProteinSequence};
+use biors_core::tokenizer::tokenize_protein;
+use biors_core::workflow::prepare_protein_model_input_workflow;
 
 #[test]
 fn public_sequence_apis_do_not_panic_on_invalid_utf8_bytes() {

--- a/packages/rust/biors/src/cli/args.rs
+++ b/packages/rust/biors/src/cli/args.rs
@@ -1,4 +1,8 @@
-use biors_core::{PaddingPolicy, ProteinTokenizerProfile, SequenceKind, SequenceKindSelection};
+use biors_core::{
+    model_input::PaddingPolicy,
+    sequence::{SequenceKind, SequenceKindSelection},
+    tokenizer::ProteinTokenizerProfile,
+};
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 use std::path::PathBuf;

--- a/packages/rust/biors/src/cli/batch.rs
+++ b/packages/rust/biors/src/cli/batch.rs
@@ -2,10 +2,8 @@ use super::{BatchCommand, KindArg};
 use crate::errors::CliError;
 use crate::input::open_fasta_input;
 use crate::output::print_success;
-use biors_core::{
-    validate_fasta_reader_summary_with_kind_and_hash, KindAwareSequenceValidationSummary,
-    SequenceKindCounts,
-};
+use biors_core::sequence::kind_validation::validate_fasta_reader_summary_with_kind_and_hash;
+use biors_core::sequence::{KindAwareSequenceValidationSummary, SequenceKindCounts};
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::fs;
@@ -182,30 +180,26 @@ fn is_fasta_path(path: &Path) -> bool {
 fn wildcard_matches(pattern: &str, text: &str) -> bool {
     let pattern: Vec<char> = pattern.chars().collect();
     let text: Vec<char> = text.chars().collect();
-    let mut matches = vec![vec![false; text.len() + 1]; pattern.len() + 1];
-    matches[0][0] = true;
+    let mut prev = vec![false; text.len() + 1];
+    let mut curr = vec![false; text.len() + 1];
+
+    prev[0] = true;
 
     for pattern_index in 1..=pattern.len() {
-        if pattern[pattern_index - 1] == '*' {
-            matches[pattern_index][0] = matches[pattern_index - 1][0];
-        }
-    }
+        curr[0] = prev[0] && pattern[pattern_index - 1] == '*';
 
-    for pattern_index in 1..=pattern.len() {
         for text_index in 1..=text.len() {
-            matches[pattern_index][text_index] = match pattern[pattern_index - 1] {
-                '*' => {
-                    matches[pattern_index - 1][text_index] || matches[pattern_index][text_index - 1]
-                }
-                '?' => matches[pattern_index - 1][text_index - 1],
-                literal => {
-                    literal == text[text_index - 1] && matches[pattern_index - 1][text_index - 1]
-                }
+            curr[text_index] = match pattern[pattern_index - 1] {
+                '*' => prev[text_index] || curr[text_index - 1],
+                '?' => prev[text_index - 1],
+                literal => literal == text[text_index - 1] && prev[text_index - 1],
             };
         }
+
+        std::mem::swap(&mut prev, &mut curr);
     }
 
-    matches[pattern.len()][text.len()]
+    prev[text.len()]
 }
 
 impl BatchValidationSummary {

--- a/packages/rust/biors/src/cli/debug.rs
+++ b/packages/rust/biors/src/cli/debug.rs
@@ -1,7 +1,10 @@
 use super::{workflow::workflow_output, PaddingArg};
 use crate::errors::CliError;
 use crate::output::print_success;
-use biors_core::{ModelInputRecord, SequenceWorkflowOutput, TokenizedProtein, ValidatedSequence};
+use biors_core::{
+    model_input::ModelInputRecord, sequence::ValidatedSequence, tokenizer::TokenizedProtein,
+    workflow::SequenceWorkflowOutput,
+};
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::PathBuf;

--- a/packages/rust/biors/src/cli/diff.rs
+++ b/packages/rust/biors/src/cli/diff.rs
@@ -1,6 +1,6 @@
 use crate::errors::CliError;
 use crate::output::print_success;
-use biors_core::diff_output_bytes;
+use biors_core::verification::diff_output_bytes;
 use std::fs;
 use std::path::PathBuf;
 

--- a/packages/rust/biors/src/cli/handlers.rs
+++ b/packages/rust/biors/src/cli/handlers.rs
@@ -11,11 +11,15 @@ use crate::input::{
 };
 use crate::output::print_success;
 use biors_core::{
-    build_model_inputs_checked, inspect_package_manifest, plan_runtime_bridge,
-    summarize_fasta_records_reader, tokenize_fasta_records_reader,
-    tokenize_fasta_records_reader_with_config, validate_fasta_reader_with_kind_and_hash,
-    validate_package_manifest_artifacts, verify_package_outputs_with_observation_base,
-    ModelInputPolicy, ProteinTokenizerConfig,
+    model_input::{build_model_inputs_checked, ModelInputPolicy},
+    package::{inspect_package_manifest, plan_runtime_bridge, validate_package_manifest_artifacts},
+    sequence::validate_fasta_reader_with_kind_and_hash,
+    tokenizer::{
+        inspect_protein_tokenizer_config, protein_tokenizer_config_for_profile,
+        summarize_fasta_records_reader, tokenize_fasta_records_reader,
+        tokenize_fasta_records_reader_with_config, ProteinTokenizerConfig,
+    },
+    verification::verify_package_outputs_with_observation_base,
 };
 use clap::CommandFactory;
 use std::path::PathBuf;
@@ -71,14 +75,22 @@ fn run_doctor() -> Result<(), CliError> {
 
 fn run_fasta_command(command: FastaCommand) -> Result<(), CliError> {
     match command {
-        FastaCommand::Validate { kind, path } => run_sequence_validation(path, kind),
+        FastaCommand::Validate { kind, path } => run_fasta_validate(kind, path),
     }
 }
 
 fn run_seq_command(command: SeqCommand) -> Result<(), CliError> {
     match command {
-        SeqCommand::Validate { kind, path } => run_sequence_validation(path, kind),
+        SeqCommand::Validate { kind, path } => run_seq_validate(kind, path),
     }
+}
+
+fn run_fasta_validate(kind: KindArg, path: PathBuf) -> Result<(), CliError> {
+    run_sequence_validation(path, kind)
+}
+
+fn run_seq_validate(kind: KindArg, path: PathBuf) -> Result<(), CliError> {
+    run_sequence_validation(path, kind)
 }
 
 fn run_inspect(path: PathBuf) -> Result<(), CliError> {
@@ -110,72 +122,80 @@ fn run_model_input(
 
 fn run_package_command(command: PackageCommand) -> Result<(), CliError> {
     match command {
-        PackageCommand::Bridge { path } => {
-            let (manifest, manifest_base_dir) = read_package_manifest(path)?;
-            let report = plan_runtime_bridge(&manifest);
-            let validation = validate_package_manifest_artifacts(&manifest, &manifest_base_dir);
-            if !validation.valid || !report.ready {
-                return Err(CliError::Validation {
-                    code: "package.bridge_not_ready",
-                    message: format!(
-                        "{:?}",
-                        validation
-                            .issues
-                            .iter()
-                            .chain(report.blocking_issues.iter())
-                            .collect::<Vec<_>>()
-                    ),
-                    location: Some("manifest".to_string()),
-                });
-            }
-            print_success(None, report)
-        }
-        PackageCommand::Inspect { path } => {
-            let (manifest, _) = read_package_manifest(path)?;
-            let summary = inspect_package_manifest(&manifest);
-            print_success(None, summary)
-        }
-        PackageCommand::Validate { path } => {
-            let (manifest, manifest_base_dir) = read_package_manifest(path)?;
-            let report = validate_package_manifest_artifacts(&manifest, &manifest_base_dir);
-            if !report.valid {
-                return Err(CliError::Validation {
-                    code: classify_validation_code(&report),
-                    message: format!("{:?}", report.issues),
-                    location: Some("manifest".to_string()),
-                });
-            }
-            print_success(None, report)
-        }
+        PackageCommand::Bridge { path } => run_package_bridge(path),
+        PackageCommand::Inspect { path } => run_package_inspect(path),
+        PackageCommand::Validate { path } => run_package_validate(path),
         PackageCommand::Verify {
             manifest,
             observations,
-        } => {
-            let (manifest, manifest_base_dir) = read_package_manifest(manifest)?;
-            let (observations, observations_base_dir) = read_fixture_observations(observations)?;
-            let report = verify_package_outputs_with_observation_base(
-                &manifest,
-                &observations,
-                &manifest_base_dir,
-                &observations_base_dir,
-            );
-            if report.failed > 0 {
-                return Err(CliError::Validation {
-                    code: classify_verification_code(&report),
-                    message: format!(
-                        "{:?}",
-                        report
-                            .results
-                            .iter()
-                            .filter_map(|result| result.issue.as_ref())
-                            .collect::<Vec<_>>()
-                    ),
-                    location: Some("fixtures".to_string()),
-                });
-            }
-            print_success(None, report)
-        }
+        } => run_package_verify(manifest, observations),
     }
+}
+
+fn run_package_bridge(path: PathBuf) -> Result<(), CliError> {
+    let (manifest, manifest_base_dir) = read_package_manifest(path)?;
+    let report = plan_runtime_bridge(&manifest);
+    let validation = validate_package_manifest_artifacts(&manifest, &manifest_base_dir);
+    if !validation.valid || !report.ready {
+        return Err(CliError::Validation {
+            code: "package.bridge_not_ready",
+            message: format!(
+                "{:?}",
+                validation
+                    .issues
+                    .iter()
+                    .chain(report.blocking_issues.iter())
+                    .collect::<Vec<_>>()
+            ),
+            location: Some("manifest".to_string()),
+        });
+    }
+    print_success(None, report)
+}
+
+fn run_package_inspect(path: PathBuf) -> Result<(), CliError> {
+    let (manifest, _) = read_package_manifest(path)?;
+    let summary = inspect_package_manifest(&manifest);
+    print_success(None, summary)
+}
+
+fn run_package_validate(path: PathBuf) -> Result<(), CliError> {
+    let (manifest, manifest_base_dir) = read_package_manifest(path)?;
+    let report = validate_package_manifest_artifacts(&manifest, &manifest_base_dir);
+    if !report.valid {
+        return Err(CliError::Validation {
+            code: classify_validation_code(&report),
+            message: format!("{:?}", report.issues),
+            location: Some("manifest".to_string()),
+        });
+    }
+    print_success(None, report)
+}
+
+fn run_package_verify(manifest: PathBuf, observations: PathBuf) -> Result<(), CliError> {
+    let (manifest, manifest_base_dir) = read_package_manifest(manifest)?;
+    let (observations, observations_base_dir) = read_fixture_observations(observations)?;
+    let report = verify_package_outputs_with_observation_base(
+        &manifest,
+        &observations,
+        &manifest_base_dir,
+        &observations_base_dir,
+    );
+    if report.failed > 0 {
+        return Err(CliError::Validation {
+            code: classify_verification_code(&report),
+            message: format!(
+                "{:?}",
+                report
+                    .results
+                    .iter()
+                    .filter_map(|result| result.issue.as_ref())
+                    .collect::<Vec<_>>()
+            ),
+            location: Some("fixtures".to_string()),
+        });
+    }
+    print_success(None, report)
 }
 
 fn run_tokenize(
@@ -194,7 +214,7 @@ fn run_tokenizer_command(command: TokenizerCommand) -> Result<(), CliError> {
     match command {
         TokenizerCommand::Inspect { profile, config } => {
             let config = resolve_tokenizer_config(profile, config)?;
-            print_success(None, biors_core::inspect_protein_tokenizer_config(&config))
+            print_success(None, inspect_protein_tokenizer_config(&config))
         }
     }
 }
@@ -205,9 +225,7 @@ fn resolve_tokenizer_config(
 ) -> Result<ProteinTokenizerConfig, CliError> {
     match config {
         Some(path) => read_tokenizer_config(path),
-        None => Ok(biors_core::protein_tokenizer_config_for_profile(
-            profile.into(),
-        )),
+        None => Ok(protein_tokenizer_config_for_profile(profile.into())),
     }
 }
 

--- a/packages/rust/biors/src/cli/pipeline.rs
+++ b/packages/rust/biors/src/cli/pipeline.rs
@@ -1,7 +1,7 @@
 use super::{workflow::workflow_output, PaddingArg};
 use crate::errors::CliError;
 use crate::output::print_success;
-use biors_core::SequenceWorkflowOutput;
+use biors_core::workflow::SequenceWorkflowOutput;
 use serde::Serialize;
 use std::path::PathBuf;
 

--- a/packages/rust/biors/src/cli/workflow.rs
+++ b/packages/rust/biors/src/cli/workflow.rs
@@ -3,8 +3,12 @@ use crate::errors::CliError;
 use crate::input::open_fasta_input;
 use crate::output::print_success;
 use biors_core::{
-    prepare_protein_model_input_workflow_with_invocation, validate_model_input_policy,
-    ModelInputPolicy, SequenceWorkflowInvocation, SequenceWorkflowOutput,
+    fasta::parse_fasta_records_reader,
+    model_input::{validate_model_input_policy, ModelInputPolicy},
+    workflow::{
+        prepare_protein_model_input_workflow_with_invocation, SequenceWorkflowInvocation,
+        SequenceWorkflowOutput,
+    },
 };
 use std::path::{Path, PathBuf};
 
@@ -32,7 +36,7 @@ pub(crate) fn workflow_output(
         padding: padding.into(),
     })?;
     let reader = open_fasta_input(&path)?;
-    let input = biors_core::parse_fasta_records_reader(reader)
+    let input = parse_fasta_records_reader(reader)
         .map_err(|error| CliError::from_fasta_read(path.clone(), error))?;
     let invocation = workflow_invocation(command, max_length, pad_token_id, padding, &path);
     prepare_protein_model_input_workflow_with_invocation(

--- a/packages/rust/biors/src/errors.rs
+++ b/packages/rust/biors/src/errors.rs
@@ -1,7 +1,9 @@
 use crate::exit_code;
 use biors_core::{
-    BioRsError, ErrorLocation, FastaReadError, ModelInputBuildError, PackageValidationIssueCode,
-    PackageValidationReport, PackageVerificationReport, VerificationIssueCode, VerificationStatus,
+    error::{BioRsError, ErrorLocation, FastaReadError},
+    model_input::ModelInputBuildError,
+    package::{PackageValidationIssueCode, PackageValidationReport},
+    verification::{PackageVerificationReport, VerificationIssueCode, VerificationStatus},
 };
 use serde::Serialize;
 use std::path::PathBuf;

--- a/packages/rust/biors/src/input.rs
+++ b/packages/rust/biors/src/input.rs
@@ -1,5 +1,7 @@
 use crate::errors::CliError;
-use biors_core::{FixtureObservation, PackageManifest, ProteinTokenizerConfig};
+use biors_core::{
+    package::PackageManifest, tokenizer::ProteinTokenizerConfig, verification::FixtureObservation,
+};
 use std::fs;
 use std::io::{self, BufRead, BufReader, Read};
 use std::path::PathBuf;

--- a/packages/rust/biors/tests/cli_batch.rs
+++ b/packages/rust/biors/tests/cli_batch.rs
@@ -1,7 +1,9 @@
 use serde_json::Value;
 use std::fs;
-use std::path::{Path, PathBuf};
 use std::process::Command;
+
+mod common;
+use common::TempDir;
 
 #[test]
 fn batch_validate_accepts_multiple_input_files() {
@@ -125,39 +127,4 @@ fn batch_validate_recurses_directories_and_reports_empty_globs() {
     assert!(glob_output.stderr.is_empty());
     let error: Value = serde_json::from_slice(&glob_output.stdout).expect("valid JSON error");
     assert_eq!(error["error"]["code"], "batch.no_inputs");
-}
-
-struct TempDir {
-    path: PathBuf,
-}
-
-impl TempDir {
-    fn new(name: &str) -> Self {
-        let path = std::env::temp_dir().join(format!(
-            "{name}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("system time")
-                .as_nanos()
-        ));
-        fs::create_dir_all(&path).expect("create temp dir");
-        Self { path }
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-
-    fn write(&self, name: &str, contents: &str) -> PathBuf {
-        let path = self.path.join(name);
-        fs::write(&path, contents).expect("write temp FASTA");
-        path
-    }
-}
-
-impl Drop for TempDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
 }

--- a/packages/rust/biors/tests/cli_diff_pipeline_debug.rs
+++ b/packages/rust/biors/tests/cli_diff_pipeline_debug.rs
@@ -1,10 +1,8 @@
 use serde_json::Value;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::path::Path;
 
 mod common;
-use common::ChildInputExt;
+use common::{ChildInputExt, TempDir};
 
 #[test]
 fn diff_reports_canonical_json_matches_and_mismatches() {
@@ -40,17 +38,8 @@ fn diff_reports_canonical_json_matches_and_mismatches() {
 
 #[test]
 fn pipeline_outputs_validate_tokenize_export_chain_without_config() {
-    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .arg("pipeline")
-        .arg("--max-length")
-        .arg("6")
-        .arg("-")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn biors pipeline")
-        .tap_stdin(">seq1\nACDE\n");
+    let output =
+        common::spawn_biors(&["pipeline", "--max-length", "6", "-"]).tap_stdin(">seq1\nACDE\n");
 
     assert!(
         output.status.success(),
@@ -73,17 +62,7 @@ fn pipeline_outputs_validate_tokenize_export_chain_without_config() {
 
 #[test]
 fn debug_outputs_step_by_step_tokens_model_input_and_error_visualization() {
-    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .arg("debug")
-        .arg("--max-length")
-        .arg("6")
-        .arg("-")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn biors debug")
-        .tap_stdin(">bad\nAX*\n");
+    let output = common::spawn_biors(&["debug", "--max-length", "6", "-"]).tap_stdin(">bad\nAX*\n");
 
     assert!(
         output.status.success(),
@@ -108,47 +87,6 @@ fn debug_outputs_step_by_step_tokens_model_input_and_error_visualization() {
 }
 
 fn run_biors(args: &[&str], paths: &[&Path]) -> Value {
-    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .args(args)
-        .args(paths)
-        .output()
-        .expect("run biors command");
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let output = common::run_biors_paths(args, paths);
     serde_json::from_slice(&output.stdout).expect("valid JSON")
-}
-
-struct TempDir {
-    path: PathBuf,
-}
-
-impl TempDir {
-    fn new(name: &str) -> Self {
-        let path = std::env::temp_dir().join(format!(
-            "{name}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("system time")
-                .as_nanos()
-        ));
-        fs::create_dir_all(&path).expect("create temp dir");
-        Self { path }
-    }
-
-    fn write(&self, name: &str, contents: &str) -> PathBuf {
-        let path = self.path.join(name);
-        fs::write(&path, contents).expect("write temp file");
-        path
-    }
-}
-
-impl Drop for TempDir {
-    fn drop(&mut self) {
-        let _ = fs::remove_dir_all(&self.path);
-    }
 }

--- a/packages/rust/biors/tests/cli_errors.rs
+++ b/packages/rust/biors/tests/cli_errors.rs
@@ -1,18 +1,10 @@
 use serde_json::Value;
-use std::process::{Command, Stdio};
 
 mod common;
 use common::ChildInputExt;
 
 fn run_biors(args: &[&str], input: &str) -> std::process::Output {
-    Command::new(env!("CARGO_BIN_EXE_biors"))
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn biors")
-        .tap_stdin(input)
+    common::spawn_biors(args).tap_stdin(input)
 }
 
 fn json_error(output: &std::process::Output) -> Value {

--- a/packages/rust/biors/tests/cli_inspect.rs
+++ b/packages/rust/biors/tests/cli_inspect.rs
@@ -1,11 +1,10 @@
 use serde_json::Value;
 
 mod common;
-use common::run_with_stdin;
 
 #[test]
 fn inspect_stdin_outputs_json_summary() {
-    let output = run_with_stdin("inspect", ">seq1\nACX\n>seq2\nM*\n");
+    let output = common::run_biors_stdin(&["inspect", "-"], ">seq1\nACX\n>seq2\nM*\n").stdout;
     let value: Value = serde_json::from_slice(&output).expect("valid JSON output");
 
     assert_eq!(value["data"]["records"], 2);

--- a/packages/rust/biors/tests/cli_tokenize.rs
+++ b/packages/rust/biors/tests/cli_tokenize.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use std::process::Command;
 
 mod common;
-use common::run_with_stdin;
 
 #[test]
 fn tokenize_multi_fasta_outputs_json_array() {
@@ -40,7 +39,7 @@ fn tokenize_multi_fasta_outputs_json_array() {
 
 #[test]
 fn tokenize_stdin_outputs_json_array() {
-    let output = run_with_stdin("tokenize", ">seq1\nACDE\n");
+    let output = common::run_biors_stdin(&["tokenize", "-"], ">seq1\nACDE\n").stdout;
     let value: Value = serde_json::from_slice(&output).expect("valid JSON output");
     let records = value["data"]
         .as_array()
@@ -53,7 +52,7 @@ fn tokenize_stdin_outputs_json_array() {
 
 #[test]
 fn tokenize_preserves_unknown_token_positions() {
-    let output = run_with_stdin("tokenize", ">seq1\nAX*\n");
+    let output = common::run_biors_stdin(&["tokenize", "-"], ">seq1\nAX*\n").stdout;
     let value: Value = serde_json::from_slice(&output).expect("valid JSON output");
     let record = &value["data"][0];
 
@@ -65,7 +64,7 @@ fn tokenize_preserves_unknown_token_positions() {
 
 #[test]
 fn public_behavior_snapshot_for_tokenize_stdout() {
-    let output = run_with_stdin("tokenize", ">seq1\nACDE\n");
+    let output = common::run_biors_stdin(&["tokenize", "-"], ">seq1\nACDE\n").stdout;
     let value: Value = serde_json::from_slice(&output).expect("valid JSON output");
 
     assert_eq!(

--- a/packages/rust/biors/tests/common/mod.rs
+++ b/packages/rust/biors/tests/common/mod.rs
@@ -1,33 +1,100 @@
 #![allow(dead_code)]
 
+use std::fs;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-pub fn run_with_stdin(command: &str, input: &str) -> Vec<u8> {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .arg(command)
-        .arg("-")
+pub struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    pub fn new(name: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn write(&self, name: &str, contents: &str) -> PathBuf {
+        let path = self.path.join(name);
+        fs::write(&path, contents).expect("write temp file");
+        path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+pub fn spawn_biors(args: &[&str]) -> std::process::Child {
+    Command::new(env!("CARGO_BIN_EXE_biors"))
+        .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .expect("spawn biors");
+        .expect("spawn biors")
+}
 
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin pipe")
-        .write_all(input.as_bytes())
-        .expect("write stdin");
+pub fn run_biors(args: &[&str]) -> std::process::Output {
+    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
+        .args(args)
+        .output()
+        .expect("run biors command");
 
-    let output = child.wait_with_output().expect("wait for biors");
     assert!(
         output.status.success(),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    output
+}
 
-    output.stdout
+pub fn run_biors_stdin(args: &[&str], input: &str) -> std::process::Output {
+    let output = spawn_biors(args).tap_stdin(input);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    output
+}
+
+pub fn run_biors_paths(args: &[&str], paths: &[&Path]) -> std::process::Output {
+    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
+        .args(args)
+        .args(paths)
+        .output()
+        .expect("run biors command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+pub fn run_biors_stdin_expect_failure(args: &[&str], input: &str) -> std::process::Output {
+    let output = spawn_biors(args).tap_stdin(input);
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stderr.is_empty());
+    output
 }
 
 pub trait ChildInputExt {

--- a/packages/rust/biors/tests/release_readiness.rs
+++ b/packages/rust/biors/tests/release_readiness.rs
@@ -1,7 +1,8 @@
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+
+mod common;
 
 #[test]
 fn full_workflow_e2e_covers_researcher_cli_path() {
@@ -285,16 +286,6 @@ fn repo_root() -> PathBuf {
 }
 
 fn run_biors(args: &[&str], paths: &[&Path]) -> Value {
-    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .args(args)
-        .args(paths)
-        .output()
-        .expect("run biors command");
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let output = common::run_biors_paths(args, paths);
     serde_json::from_slice(&output.stdout).expect("valid JSON")
 }

--- a/packages/rust/biors/tests/schema_contract.rs
+++ b/packages/rust/biors/tests/schema_contract.rs
@@ -1,9 +1,9 @@
 use jsonschema::JSONSchema;
 use serde_json::Value;
 use std::fs;
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
+
+mod common;
 
 #[test]
 fn machine_readable_schemas_are_valid_json() {
@@ -68,64 +68,106 @@ fn package_manifest_example_uses_declared_schema_version() {
 }
 
 #[test]
-fn cli_outputs_match_declared_payload_schemas() {
-    let tokenize = run_with_stdin(["tokenize", "-"], ">seq1\nACDE\n");
+fn cli_outputs_match_sequence_schemas() {
+    let tokenize = common::run_biors_stdin(&["tokenize", "-"], ">seq1\nACDE\n").stdout;
     assert_payload_matches_schema(&tokenize, "schemas/tokenize-output.v0.json");
 
-    let repo = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
-    let special_config = repo.join("examples/model-input-contract/protein-20-special.config.json");
-    let special_fasta = repo.join("examples/model-input-contract/protein.fasta");
-    let special_tokenize = run_command(
-        ["tokenize", "--config"],
-        &[special_config.as_os_str(), special_fasta.as_os_str()],
-    );
+    let special_config =
+        repo_root().join("examples/model-input-contract/protein-20-special.config.json");
+    let special_fasta = repo_root().join("examples/model-input-contract/protein.fasta");
+    let special_tokenize = common::run_biors_paths(
+        &["tokenize", "--config"],
+        &[&special_config, &special_fasta],
+    )
+    .stdout;
     assert_payload_matches_schema(&special_tokenize, "schemas/tokenize-output.v0.json");
 
-    let inspect = run_with_stdin(["inspect", "-"], ">seq1\nACDE\n>seq2\nAX\n");
+    let inspect = common::run_biors_stdin(&["inspect", "-"], ">seq1\nACDE\n>seq2\nAX\n").stdout;
     assert_payload_matches_schema(&inspect, "schemas/inspect-output.v0.json");
 
-    let fasta_validate = run_with_stdin(["fasta", "validate", "-"], ">seq1\nAX*\n");
+    let fasta_validate =
+        common::run_biors_stdin(&["fasta", "validate", "-"], ">seq1\nAX*\n").stdout;
     assert_payload_matches_schema(&fasta_validate, "schemas/fasta-validation-output.v0.json");
 
-    let seq_validate = run_with_stdin(["seq", "validate", "-"], ">seq1\nACGN\n");
+    let seq_validate = common::run_biors_stdin(&["seq", "validate", "-"], ">seq1\nACGN\n").stdout;
     assert_payload_matches_schema(&seq_validate, "schemas/fasta-validation-output.v0.json");
 
-    let model_input = run_with_stdin(["model-input", "--max-length", "4", "-"], ">seq1\nACDEFG\n");
+    let model_input = common::run_biors_stdin(
+        &["model-input", "--max-length", "4", "-"],
+        ">seq1\nACDEFG\n",
+    )
+    .stdout;
     assert_payload_matches_schema(&model_input, "schemas/model-input-output.v0.json");
 
-    let workflow = run_with_stdin(["workflow", "--max-length", "4", "-"], ">seq1\nACDEFG\n");
+    let workflow =
+        common::run_biors_stdin(&["workflow", "--max-length", "4", "-"], ">seq1\nACDEFG\n").stdout;
     assert_payload_matches_schema(&workflow, "schemas/sequence-workflow-output.v0.json");
 
-    let pipeline = run_with_stdin(["pipeline", "--max-length", "4", "-"], ">seq1\nACDE\n");
+    let pipeline =
+        common::run_biors_stdin(&["pipeline", "--max-length", "4", "-"], ">seq1\nACDE\n").stdout;
     assert_payload_matches_schema(&pipeline, "schemas/pipeline-output.v0.json");
 
-    let debug = run_with_stdin(["debug", "--max-length", "4", "-"], ">seq1\nAX*\n");
+    let debug =
+        common::run_biors_stdin(&["debug", "--max-length", "4", "-"], ">seq1\nAX*\n").stdout;
     assert_payload_matches_schema(&debug, "schemas/sequence-debug-output.v0.json");
+}
 
-    let expected = repo.join("examples/protein-package/fixtures/tiny.output.json");
-    let observed = repo.join("examples/protein-package/observed/tiny.reordered.json");
-    let diff = run_command(["diff"], &[expected.as_os_str(), observed.as_os_str()]);
+#[test]
+fn cli_outputs_match_diff_schema() {
+    let expected = repo_root().join("examples/protein-package/fixtures/tiny.output.json");
+    let observed = repo_root().join("examples/protein-package/observed/tiny.reordered.json");
+    let diff = common::run_biors_paths(&["diff"], &[&expected, &observed]).stdout;
     assert_payload_matches_schema(&diff, "schemas/output-diff.v0.json");
+}
 
-    let examples = repo.join("examples");
-    let batch_validate = run_command(
-        ["batch", "validate", "--kind", "auto"],
-        &[examples.as_os_str()],
-    );
+#[test]
+fn cli_outputs_match_batch_schema() {
+    let examples = repo_root().join("examples");
+    let batch_validate =
+        common::run_biors_paths(&["batch", "validate", "--kind", "auto"], &[&examples]).stdout;
     assert_payload_matches_schema(&batch_validate, "schemas/batch-validation-output.v0.json");
+}
 
-    let tokenizer_inspect = run_command(
-        ["tokenizer", "inspect", "--profile", "protein-20-special"],
+#[test]
+fn cli_outputs_match_tooling_schemas() {
+    let tokenizer_inspect = common::run_biors_paths(
+        &["tokenizer", "inspect", "--profile", "protein-20-special"],
         &[],
-    );
+    )
+    .stdout;
     assert_payload_matches_schema(
         &tokenizer_inspect,
         "schemas/tokenizer-inspect-output.v0.json",
     );
 
-    let doctor = run_command(["doctor"], &[]);
+    let doctor = common::run_biors_paths(&["doctor"], &[]).stdout;
     assert_payload_matches_schema(&doctor, "schemas/doctor-output.v0.json");
+}
 
+#[test]
+fn cli_outputs_match_package_schemas() {
+    let manifest = repo_root().join("examples/protein-package/manifest.json");
+    let observations = repo_root().join("examples/protein-package/observations.json");
+
+    let package_inspect = common::run_biors_paths(&["package", "inspect"], &[&manifest]).stdout;
+    assert_payload_matches_schema(&package_inspect, "schemas/package-inspect-output.v0.json");
+
+    let package_validate = common::run_biors_paths(&["package", "validate"], &[&manifest]).stdout;
+    assert_payload_matches_schema(
+        &package_validate,
+        "schemas/package-validation-report.v0.json",
+    );
+
+    let package_bridge = common::run_biors_paths(&["package", "bridge"], &[&manifest]).stdout;
+    assert_payload_matches_schema(&package_bridge, "schemas/package-bridge-output.v0.json");
+
+    let package_verify =
+        common::run_biors_paths(&["package", "verify"], &[&manifest, &observations]).stdout;
+    assert_payload_matches_schema(&package_verify, "schemas/package-verify-output.v0.json");
+}
+
+#[test]
+fn cli_rejections_match_schemas() {
     let zero_model_input = serde_json::json!({
         "policy": {
             "max_length": 0,
@@ -135,27 +177,6 @@ fn cli_outputs_match_declared_payload_schemas() {
         "records": []
     });
     assert_payload_rejected_by_schema(&zero_model_input, "schemas/model-input-output.v0.json");
-
-    let manifest = repo.join("examples/protein-package/manifest.json");
-    let observations = repo.join("examples/protein-package/observations.json");
-
-    let package_inspect = run_command(["package", "inspect"], &[manifest.as_os_str()]);
-    assert_payload_matches_schema(&package_inspect, "schemas/package-inspect-output.v0.json");
-
-    let package_validate = run_command(["package", "validate"], &[manifest.as_os_str()]);
-    assert_payload_matches_schema(
-        &package_validate,
-        "schemas/package-validation-report.v0.json",
-    );
-
-    let package_bridge = run_command(["package", "bridge"], &[manifest.as_os_str()]);
-    assert_payload_matches_schema(&package_bridge, "schemas/package-bridge-output.v0.json");
-
-    let package_verify = run_command(
-        ["package", "verify"],
-        &[manifest.as_os_str(), observations.as_os_str()],
-    );
-    assert_payload_matches_schema(&package_verify, "schemas/package-verify-output.v0.json");
 
     let mismatch_report = serde_json::json!({
         "package": "protein-seed",
@@ -194,10 +215,11 @@ fn cli_outputs_match_declared_payload_schemas() {
 
 #[test]
 fn cli_outputs_match_success_and_error_envelope_schemas() {
-    let success = run_with_stdin(["tokenize", "-"], ">seq1\nACDE\n");
+    let success = common::run_biors_stdin(&["tokenize", "-"], ">seq1\nACDE\n").stdout;
     assert_json_matches_schema(&success, "schemas/cli-success.v0.json");
 
-    let error = run_with_stdin_expect_failure(["--json", "tokenize", "-"], "ACDE\n");
+    let error =
+        common::run_biors_stdin_expect_failure(&["--json", "tokenize", "-"], "ACDE\n").stdout;
     assert_json_matches_schema(&error, "schemas/cli-error.v0.json");
 }
 
@@ -226,6 +248,10 @@ fn assert_json_value_matches_schema(value: &Value, schema_path: &str) {
     }
 }
 
+fn repo_root() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..")
+}
+
 fn assert_payload_rejected_by_schema(payload: &Value, schema_path: &str) {
     let repo = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../..");
     let schema: Value = serde_json::from_str(
@@ -238,55 +264,4 @@ fn assert_payload_rejected_by_schema(payload: &Value, schema_path: &str) {
         compiled.validate(payload).is_err(),
         "payload unexpectedly matched schema {schema_path}"
     );
-}
-
-fn spawn_with_stdin<const N: usize>(args: [&str; N], input: &str) -> std::process::Output {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn biors");
-
-    child
-        .stdin
-        .take()
-        .unwrap()
-        .write_all(input.as_bytes())
-        .expect("write stdin");
-
-    child.wait_with_output().expect("wait for biors")
-}
-
-fn run_with_stdin<const N: usize>(args: [&str; N], input: &str) -> Vec<u8> {
-    let output = spawn_with_stdin(args, input);
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    output.stdout
-}
-
-fn run_with_stdin_expect_failure<const N: usize>(args: [&str; N], input: &str) -> Vec<u8> {
-    let output = spawn_with_stdin(args, input);
-    assert_eq!(output.status.code(), Some(2));
-    assert!(output.stderr.is_empty());
-    output.stdout
-}
-
-fn run_command<const N: usize>(args: [&str; N], extra_args: &[&std::ffi::OsStr]) -> Vec<u8> {
-    let output = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .args(args)
-        .args(extra_args)
-        .output()
-        .expect("run biors");
-
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    output.stdout
 }

--- a/packages/rust/biors/tests/sequence_cli.rs
+++ b/packages/rust/biors/tests/sequence_cli.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
-use std::io::Write;
-use std::process::{Command, Output, Stdio};
+use std::process::Output;
+
+mod common;
 
 #[test]
 fn fasta_validate_kind_flag_outputs_kind_aware_report() {
@@ -60,29 +61,7 @@ fn seq_validate_kind_override_uses_kind_specific_messages() {
 }
 
 fn run_with_stdin<const N: usize>(args: [&str; N], input: &str) -> Output {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_biors"))
-        .args(args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn biors");
-
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(input.as_bytes())
-        .expect("write stdin");
-
-    let output = child.wait_with_output().expect("wait for biors");
-    assert!(
-        output.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(output.stderr.is_empty());
-    output
+    common::run_biors_stdin(&args, input)
 }
 
 fn assert_mixed_kind_counts(output: &Output) {


### PR DESCRIPTION
## Summary

Production-grade refactoring of the entire bio-rs codebase across 5 dimensions:

### Group A — Performance
- Remove double allocation in sequence validation (`sequence.clone()` + `String::from_utf8`)
- Add capacity hints to `Vec::new()` in `fasta_scan`, `tokenizer/protein` hot paths
- Replace `while-push` loop with `resize()` in `model_input` padding
- Replace iterator collect with slice clone for token slicing

### Group B — API Cleanup
- Remove deprecated `build_model_inputs` and its re-export
- Tighten visibility: `resolve_package_path`, `validate_package_relative_path` → `pub(crate)`
- Reduce `lib.rs` re-exports from ~50 to 14 most common entry points

### Group C — Architecture
- Replace wildcard re-exports with explicit ones in `package.rs`, `verification.rs`
- Move `fasta/kind_validation.rs` → `sequence/kind_validation.rs`
- Update ~30 downstream imports across core, CLI, tests, examples

### Group D — CLI
- Extract inline handlers from `run_package_command` into dedicated functions
- Optimize `wildcard_matches` from 2D DP matrix to 2-row algorithm
- Eliminate 2 of 3 heap allocations in glob matching

### Group E — Test Structure
- Extract shared `TempDir` into `tests/common/mod.rs`
- Unify CLI spawn helpers across 7 test files
- Split `schema_contract` monolithic test into 6 focused tests by family

### Verification
- `cargo test --workspace --all-targets --all-features`: **ALL PASS**
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: **CLEAN**
- `cargo check -p biors-core --target wasm32-unknown-unknown`: **CLEAN**
- `scripts/check.sh`: **ALL CHECKS PASS**

**BREAKING CHANGE**: Public API surface reduced. Types previously re-exported at crate root (`PackageManifest`, `VerificationReport`, etc.) now require module paths (`biors_core::package::PackageManifest`). Core workflow types remain at root.