### PR TITLE
feat(package): add model runtime compatibility checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "biors"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "biors-core",
  "clap",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "biors-backend-candle"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "biors-core",
  "candle-core",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "biors-core"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "criterion",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bio-rs/bio-rs"
-version = "0.40.0"
+version = "0.41.0"
 
 [workspace.dependencies]
-biors-core = { version = "0.40.0", path = "packages/rust/biors-core" }
+biors-core = { version = "0.41.0", path = "packages/rust/biors-core" }
 candle-core = { version = "0.10.2", default-features = false }
 clap = { version = "4.5.37", features = ["derive"] }
 clap_complete = "4.5.48"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The goal is to make the input layer around bio-AI models faster, more portable, 
 ## Quickstart
 
 ```bash
-cargo install biors --version 0.40.0
+cargo install biors --version 0.41.0
 biors tokenize examples/protein.fasta
 biors workflow --max-length 8 examples/protein.fasta
 biors batch validate --kind auto examples/

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ shape.
 - Runtime bridge planning reports, backend execution abstraction contracts, and
   guarded external-process backend adapters
 - Optional Candle backend crate for CPU safetensors linear-probe inference
+- Model artifact metadata and runtime/model compatibility checks in package
+  bridge reports
 - Typed validation issue codes and manifest enums
 
 ### Utilities

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -161,7 +161,7 @@ stdout and stderr from external tools as untrusted process output.
 
 ## Crate Split Review
 
-`crates/biors-runtime` is still not introduced in `0.40.0`.
+`crates/biors-runtime` is still not introduced in `0.41.0`.
 
 Rationale:
 

--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -40,6 +40,16 @@ The `0.40.0` scope adds an optional Candle backend crate:
 - no Candle dependency in `biors-core`
 - no backend-enabled CLI binary artifact by default
 
+The `0.41.0` scope connects package manifests to the runtime planning layer:
+
+- optional model artifact metadata on package `model`
+- manifest support for ONNX/WebGPU and safetensors/Candle CPU compatibility
+  pairs
+- structured `package bridge` compatibility checks
+- explicit blocking issues when a model format, backend, and target do not
+  match
+- no runtime launch command or backend-enabled CLI binary artifact
+
 ## Runtime Contracts
 
 `Backend` owns three responsibilities:
@@ -173,9 +183,9 @@ with heavier dependencies.
 
 Concrete backend work belongs in later versions:
 
-- `0.41.0`: model artifact metadata and backend compatibility checks
+- later phases may add backend-specific CLI wiring once package
+  compatibility and artifact contracts are stable
 
-Until the compatibility and artifact phases land, package runtime bridge reports
-remain planning and compatibility surfaces. Candle execution is available only
-through the optional backend crate and is not wired into package manifests or
-the default CLI binary.
+Package runtime bridge reports remain planning and compatibility surfaces.
+Candle execution is available only through the optional backend crate and is not
+wired into the default CLI binary.

--- a/docs/candle-backend.md
+++ b/docs/candle-backend.md
@@ -55,16 +55,16 @@ configured backend id.
 
 ## Device And Feature Policy
 
-The `0.40.0` backend supports CPU execution. CUDA, Metal, Accelerate, MKL, and
-other device-specific Candle features remain out of the default workspace build.
-Those should be added behind explicit crate features only after platform CI and
-artifact policy are defined.
+The backend currently supports CPU execution. CUDA, Metal, Accelerate, MKL,
+and other device-specific Candle features remain out of the default workspace
+build. Those should be added behind explicit crate features only after platform
+CI and artifact policy are defined.
 
 ## Core And CLI Separation
 
 `biors-core` does not depend on Candle. The `biors` CLI does not link this
 backend by default and no backend-enabled binary artifact is produced in
-`0.40.0`.
+`0.41.0`.
 
 Rationale:
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -149,8 +149,8 @@ Package skeleton reports use `schemas/package-skeleton-output.v0.json`.
 `package init` and `package convert-project` create a local package layout,
 write docs and pipeline config, copy supplied fixture artifacts, and record
 SHA-256 checksums. Python project conversion scans for an ONNX model and
-`tokenizer_config.json`; model artifact metadata beyond path/checksum is not
-imported by this layer.
+`tokenizer_config.json`; optional model artifact metadata is left unset for
+the package author to fill in.
 
 FASTA validation reports include `kind_counts` and per-record `kind` /
 `alphabet` fields. Sequence warnings and errors expose stable issue codes such

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -26,7 +26,7 @@ sh scripts/launch-demo.sh --cargo
 ## Run With An Installed Binary
 
 ```bash
-cargo install biors --version 0.40.0
+cargo install biors --version 0.41.0
 biors --version
 sh scripts/launch-demo.sh
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@ bio-rs supports three install paths for the pre-1.0 line.
 ## Cargo Install
 
 ```bash
-cargo install biors --version 0.40.0
+cargo install biors --version 0.41.0
 biors --version
 biors doctor
 ```

--- a/docs/package-conversion.md
+++ b/docs/package-conversion.md
@@ -4,9 +4,10 @@ This guide covers the package conversion path for Python and Hugging Face based
 projects.
 
 The conversion layer builds portable bio-rs package structure and records
-checksums. It does not inspect or import model artifact metadata beyond local
-path and SHA-256; model artifact metadata belongs to the execution backend
-layer.
+checksums. It does not infer optional model artifact metadata such as model
+name, version, architecture, task, source, or description. Package authors can
+add `model.metadata` after conversion when they want inspect and bridge reports
+to carry that context.
 
 ## Hugging Face Tokenizer Config
 

--- a/docs/package-format.md
+++ b/docs/package-format.md
@@ -78,6 +78,50 @@ Package metadata is intentionally explicit. A researcher should be able to
 inspect the package and know whether the artifact can be redistributed, how to
 cite it, and what the model card says before running inference.
 
+## Model Artifact Metadata
+
+Package manifests can attach optional model artifact metadata directly to the
+`model` section:
+
+```json
+{
+  "model": {
+    "format": "onnx",
+    "path": "models/protein-seed.onnx",
+    "checksum": "sha256:...",
+    "metadata": {
+      "name": "protein-seed-linear-probe",
+      "version": "fixture-0",
+      "architecture": "linear-probe",
+      "task": "classification",
+      "source": "local-fixture",
+      "description": "Tiny deterministic package fixture model."
+    }
+  }
+}
+```
+
+`metadata.name` is required when the metadata object is present. The remaining
+fields are optional and are intended for inspect output, bridge planning, and
+future package registry surfaces. They are descriptive metadata, not execution
+instructions.
+
+## Runtime Compatibility
+
+`biors package bridge` now reports deterministic compatibility checks between
+the model artifact format and the declared runtime backend/target pair. Current
+planning pairs are:
+
+| Model format | Runtime backend | Runtime target | Execution provider |
+| --- | --- | --- | --- |
+| `onnx` | `onnx-webgpu` | `browser-wasm-webgpu` | `webgpu` |
+| `safetensors` | `candle` | `local-cpu` | `candle-cpu` |
+
+An incompatible pair, such as `onnx` with `candle/local-cpu`, produces a
+blocking issue in the bridge report. This is a compatibility contract only; it
+does not launch a browser, start a service, or link the optional Candle backend
+into the default CLI binary.
+
 Preprocessing steps may also reference a checked pipeline config artifact:
 
 ```json
@@ -113,8 +157,8 @@ intended-use, and limitations.
 `biors tokenizer convert-hf`, `biors package init`, and
 `biors package convert-project` cover the Python/Hugging Face project path.
 They write package layout, tokenizer config, pipeline config, docs, fixture
-references, and checksums without importing model artifact metadata beyond
-path and SHA-256. See [Package Conversion](package-conversion.md).
+references, and checksums while leaving optional `model.metadata` for the
+package author to fill in. See [Package Conversion](package-conversion.md).
 
 `biors package compatibility <left-manifest> <right-manifest>` reports the
 schema transition from left to right, whether a migration is required, and

--- a/docs/pipeline-config.md
+++ b/docs/pipeline-config.md
@@ -100,7 +100,7 @@ Unknown fields and unsupported values fail with `pipeline.invalid_config`.
 
 ## Crate Split Review
 
-`biors-pipeline` remains deferred in v0.40.0.
+`biors-pipeline` remains deferred in v0.41.0.
 
 Rationale:
 

--- a/docs/public-contract-1.0-candidates.md
+++ b/docs/public-contract-1.0-candidates.md
@@ -33,7 +33,9 @@ The following surfaces are candidates for stabilization before the first stable 
 - `SequenceWorkflowOutput`, `SequenceWorkflowProvenance`, `SequenceWorkflowInvocation`, `SequenceWorkflowHashes`, `SequenceWorkflowReadinessIssue`
 - `diff_output_bytes`, `OutputDiffReport`
 - `validate_package_manifest_artifacts`
-- `PackageManifest`, `PipelineConfigArtifact`, `PackageValidationIssue`, `PackageValidationReport`, `RuntimeBridgeReport`
+- `PackageManifest`, `ModelArtifactMetadata`, `ModelArtifactMetadataSummary`,
+  `BackendCompatibilityCheck`, `PipelineConfigArtifact`,
+  `PackageValidationIssue`, `PackageValidationReport`, `RuntimeBridgeReport`
 - `Backend`, `BackendConfig`, `BackendCapabilities`, `BackendCompatibilityReport`, `RuntimeCompatibilityIssue`, `RuntimeCompatibilityIssueCode`, `ExecutionContext`, `ExecutionResult`, `BackendExecutionError`, `ExternalProcessBackend`, `ExternalProcessConfig`
 - `biors-backend-candle`: `CandleBackend`, `CandleBackendConfig`, `CandleDevice`, `CandleInferenceOutput`, `CANDLE_MODEL_INPUT_FORMAT`, `CANDLE_OUTPUT_FORMAT`
 - `PackageVerificationReport`, `FixtureObservation`, `VerificationIssueCode`, `ContentMismatchDiff`
@@ -83,7 +85,7 @@ The following surfaces are candidates for stabilization before the first stable 
 ## Not Yet Stable
 
 - package runtime bridge provider expansion beyond the current `onnx-webgpu`
-  planning target
+  and `candle` planning targets
 - concrete runtime backend implementations beyond the external process adapter
   and optional Candle linear-probe crate
 - larger fixture verification formats

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -232,7 +232,7 @@ biors package validate ./protein-package/manifest.json
 `package convert-project` scans for an ONNX model and `tokenizer_config.json`,
 converts supported Hugging Face tokenizer metadata to bio-rs tokenizer config,
 creates package docs, writes a pipeline config, records checksums, and leaves
-model artifact metadata beyond path/checksum to the execution backend layer.
+optional model artifact metadata unset for the package author to fill in.
 
 ## Inspect The Local Artifact Store
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ fresh checkout.
 ## Install
 
 ```bash
-cargo install biors --version 0.40.0
+cargo install biors --version 0.41.0
 biors --version
 biors doctor
 ```

--- a/examples/protein-package/manifest.json
+++ b/examples/protein-package/manifest.json
@@ -44,7 +44,15 @@
   "model": {
     "format": "onnx",
     "path": "models/protein-seed.onnx",
-    "checksum": "sha256:2c1da72b15fab35bd6f1bb62f5037b936e26e6413a220fa9afe5a64bce0df68d"
+    "checksum": "sha256:2c1da72b15fab35bd6f1bb62f5037b936e26e6413a220fa9afe5a64bce0df68d",
+    "metadata": {
+      "name": "protein-seed-linear-probe",
+      "version": "fixture-0",
+      "architecture": "linear-probe",
+      "task": "classification",
+      "source": "local-fixture",
+      "description": "Tiny deterministic package fixture model used for local validation."
+    }
   },
   "tokenizer": {
     "name": "protein-20",

--- a/packages/rust/biors-core/src/package.rs
+++ b/packages/rust/biors-core/src/package.rs
@@ -16,13 +16,14 @@ pub use artifacts::validate_package_manifest_artifacts;
 pub use checksum::{is_sha256_checksum, sha256_digest};
 pub use manifest::{
     CitationMetadata, DataShape, DocumentArtifact, LicenseMetadata, ModelArtifact,
-    ModelCardMetadata, PackageDirectoryLayout, PackageFixture, PackageManifest, PackageMetadata,
-    PipelineConfigArtifact, PipelineStep, RuntimeTarget, TokenAsset,
+    ModelArtifactMetadata, ModelCardMetadata, PackageDirectoryLayout, PackageFixture,
+    PackageManifest, PackageMetadata, PipelineConfigArtifact, PipelineStep, RuntimeTarget,
+    TokenAsset,
 };
 pub use reports::{
-    PackageDirectoryLayoutSummary, PackageLayoutSummary, PackageManifestSummary,
-    PackageMetadataSummary, PackageValidationIssue, PackageValidationIssueCode,
-    PackageValidationReport, RuntimeBridgeReport,
+    BackendCompatibilityCheck, ModelArtifactMetadataSummary, PackageDirectoryLayoutSummary,
+    PackageLayoutSummary, PackageManifestSummary, PackageMetadataSummary, PackageValidationIssue,
+    PackageValidationIssueCode, PackageValidationReport, RuntimeBridgeReport,
 };
 pub use runtime::plan_runtime_bridge;
 pub use summary::inspect_package_manifest;

--- a/packages/rust/biors-core/src/package/manifest.rs
+++ b/packages/rust/biors-core/src/package/manifest.rs
@@ -93,6 +93,23 @@ pub struct ModelArtifact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Optional `sha256:<64 hex>` checksum for the artifact.
     pub checksum: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<ModelArtifactMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelArtifactMetadata {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/packages/rust/biors-core/src/package/reports.rs
+++ b/packages/rust/biors-core/src/package/reports.rs
@@ -1,4 +1,6 @@
-use super::{ModelFormat, RuntimeBackend, RuntimeTargetPlatform, SchemaVersion};
+use super::{
+    ModelArtifactMetadata, ModelFormat, RuntimeBackend, RuntimeTargetPlatform, SchemaVersion,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -10,6 +12,7 @@ pub struct PackageManifestSummary {
     pub metadata: Option<PackageMetadataSummary>,
     pub model_format: ModelFormat,
     pub has_model_checksum: bool,
+    pub model_metadata: Option<ModelArtifactMetadataSummary>,
     pub tokenizer: Option<String>,
     pub vocab: Option<String>,
     pub runtime_backend: RuntimeBackend,
@@ -40,6 +43,22 @@ pub struct PackageMetadataSummary {
     pub license: String,
     pub citation: String,
     pub model_card: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Compact model artifact metadata returned by inspect and runtime planning.
+pub struct ModelArtifactMetadataSummary {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -97,8 +116,32 @@ pub struct RuntimeBridgeReport {
     pub ready: bool,
     pub backend: RuntimeBackend,
     pub target: RuntimeTargetPlatform,
+    pub model_format: ModelFormat,
+    pub model_metadata: Option<ModelArtifactMetadataSummary>,
     pub execution_provider: String,
+    pub compatibility_checks: Vec<BackendCompatibilityCheck>,
     pub blocking_issues: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// One deterministic runtime compatibility decision.
+pub struct BackendCompatibilityCheck {
+    pub code: String,
+    pub passed: bool,
+    pub message: String,
+}
+
+impl From<&ModelArtifactMetadata> for ModelArtifactMetadataSummary {
+    fn from(metadata: &ModelArtifactMetadata) -> Self {
+        Self {
+            name: metadata.name.clone(),
+            version: metadata.version.clone(),
+            architecture: metadata.architecture.clone(),
+            task: metadata.task.clone(),
+            source: metadata.source.clone(),
+            description: metadata.description.clone(),
+        }
+    }
 }
 
 impl PackageValidationReport {

--- a/packages/rust/biors-core/src/package/runtime.rs
+++ b/packages/rust/biors-core/src/package/runtime.rs
@@ -1,14 +1,78 @@
-use super::{validate_package_manifest, PackageManifest, RuntimeBridgeReport};
+use super::{
+    validate_package_manifest, BackendCompatibilityCheck, ModelArtifactMetadataSummary,
+    ModelFormat, PackageManifest, RuntimeBackend, RuntimeBridgeReport, RuntimeTargetPlatform,
+};
 
 /// Build a runtime bridge readiness report from a package manifest.
 pub fn plan_runtime_bridge(manifest: &PackageManifest) -> RuntimeBridgeReport {
-    let blocking_issues = validate_package_manifest(manifest).issues;
+    let mut blocking_issues = validate_package_manifest(manifest).issues;
+    let compatibility_checks = vec![runtime_model_pair_check(manifest)];
+
+    blocking_issues.extend(
+        compatibility_checks
+            .iter()
+            .filter(|check| !check.passed)
+            .map(|check| check.message.clone()),
+    );
 
     RuntimeBridgeReport {
         ready: blocking_issues.is_empty(),
         backend: manifest.runtime.backend,
         target: manifest.runtime.target,
-        execution_provider: "webgpu".to_string(),
+        model_format: manifest.model.format,
+        model_metadata: manifest
+            .model
+            .metadata
+            .as_ref()
+            .map(ModelArtifactMetadataSummary::from),
+        execution_provider: execution_provider(manifest),
+        compatibility_checks,
         blocking_issues,
     }
+}
+
+fn runtime_model_pair_check(manifest: &PackageManifest) -> BackendCompatibilityCheck {
+    let passed = matches!(
+        (
+            manifest.model.format,
+            manifest.runtime.backend,
+            manifest.runtime.target
+        ),
+        (
+            ModelFormat::Onnx,
+            RuntimeBackend::OnnxWebgpu,
+            RuntimeTargetPlatform::BrowserWasmWebgpu
+        ) | (
+            ModelFormat::Safetensors,
+            RuntimeBackend::Candle,
+            RuntimeTargetPlatform::LocalCpu
+        )
+    );
+
+    let message = if passed {
+        format!(
+            "{}/{} supports {} model artifacts",
+            manifest.runtime.backend, manifest.runtime.target, manifest.model.format
+        )
+    } else {
+        format!(
+            "model format '{}' is not compatible with backend '{}' target '{}'",
+            manifest.model.format, manifest.runtime.backend, manifest.runtime.target
+        )
+    };
+
+    BackendCompatibilityCheck {
+        code: "runtime_model_pair".to_string(),
+        passed,
+        message,
+    }
+}
+
+fn execution_provider(manifest: &PackageManifest) -> String {
+    match (manifest.runtime.backend, manifest.runtime.target) {
+        (RuntimeBackend::OnnxWebgpu, RuntimeTargetPlatform::BrowserWasmWebgpu) => "webgpu",
+        (RuntimeBackend::Candle, RuntimeTargetPlatform::LocalCpu) => "candle-cpu",
+        _ => "unsupported",
+    }
+    .to_string()
 }

--- a/packages/rust/biors-core/src/package/summary.rs
+++ b/packages/rust/biors-core/src/package/summary.rs
@@ -1,6 +1,7 @@
 use super::{
-    PackageDirectoryLayout, PackageDirectoryLayoutSummary, PackageLayoutSummary, PackageManifest,
-    PackageManifestSummary, PackageMetadata, PackageMetadataSummary,
+    ModelArtifactMetadataSummary, PackageDirectoryLayout, PackageDirectoryLayoutSummary,
+    PackageLayoutSummary, PackageManifest, PackageManifestSummary, PackageMetadata,
+    PackageMetadataSummary,
 };
 
 /// Build a compact summary of a package manifest for inspect-style output.
@@ -12,6 +13,11 @@ pub fn inspect_package_manifest(manifest: &PackageManifest) -> PackageManifestSu
         metadata: manifest.metadata.as_ref().map(metadata_summary),
         model_format: manifest.model.format,
         has_model_checksum: manifest.model.checksum.is_some(),
+        model_metadata: manifest
+            .model
+            .metadata
+            .as_ref()
+            .map(ModelArtifactMetadataSummary::from),
         tokenizer: manifest
             .tokenizer
             .as_ref()

--- a/packages/rust/biors-core/src/package/tooling/tests.rs
+++ b/packages/rust/biors-core/src/package/tooling/tests.rs
@@ -18,6 +18,7 @@ fn minimal_manifest(name: &str, schema_version: SchemaVersion) -> PackageManifes
             format: ModelFormat::Onnx,
             path: "model.onnx".to_string(),
             checksum: None,
+            metadata: None,
         },
         tokenizer: None,
         vocab: None,

--- a/packages/rust/biors-core/src/package/types.rs
+++ b/packages/rust/biors-core/src/package/types.rs
@@ -13,18 +13,24 @@ pub enum SchemaVersion {
 pub enum ModelFormat {
     #[serde(rename = "onnx")]
     Onnx,
+    #[serde(rename = "safetensors")]
+    Safetensors,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RuntimeBackend {
     #[serde(rename = "onnx-webgpu")]
     OnnxWebgpu,
+    #[serde(rename = "candle")]
+    Candle,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RuntimeTargetPlatform {
     #[serde(rename = "browser-wasm-webgpu")]
     BrowserWasmWebgpu,
+    #[serde(rename = "local-cpu")]
+    LocalCpu,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -54,6 +60,7 @@ impl fmt::Display for ModelFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Self::Onnx => "onnx",
+            Self::Safetensors => "safetensors",
         })
     }
 }
@@ -62,6 +69,7 @@ impl fmt::Display for RuntimeBackend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Self::OnnxWebgpu => "onnx-webgpu",
+            Self::Candle => "candle",
         })
     }
 }
@@ -70,6 +78,7 @@ impl fmt::Display for RuntimeTargetPlatform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             Self::BrowserWasmWebgpu => "browser-wasm-webgpu",
+            Self::LocalCpu => "local-cpu",
         })
     }
 }

--- a/packages/rust/biors-core/src/package/validation.rs
+++ b/packages/rust/biors-core/src/package/validation.rs
@@ -10,6 +10,9 @@ pub fn validate_package_manifest(manifest: &PackageManifest) -> PackageValidatio
     push_required_issue(&mut report, "name", &manifest.name);
     validate_v1_contract(&mut report, manifest);
     push_required_issue(&mut report, "model.path", &manifest.model.path);
+    if let Some(metadata) = &manifest.model.metadata {
+        push_required_issue(&mut report, "model.metadata.name", &metadata.name);
+    }
     validate_fixture_list(&mut report, manifest);
     validate_optional_shape(
         &mut report,

--- a/packages/rust/biors-core/tests/package.rs
+++ b/packages/rust/biors-core/tests/package.rs
@@ -78,6 +78,85 @@ fn inspects_portable_package_manifest() {
 }
 
 #[test]
+fn inspects_model_artifact_metadata_for_runtime_planning() {
+    let manifest: PackageManifest = serde_json::from_str(
+        r#"{
+          "schema_version": "biors.package.v1",
+          "name": "protein-seed",
+          "package_layout": {
+            "manifest": "manifest.json",
+            "models": "models",
+            "fixtures": "fixtures",
+            "docs": "docs"
+          },
+          "metadata": {
+            "license": { "expression": "CC0-1.0" },
+            "citation": { "preferred_citation": "bio-rs package fixture" },
+            "model_card": {
+              "path": "docs/model-card.md",
+              "summary": "Tiny deterministic package fixture.",
+              "intended_use": ["Validate package tooling"],
+              "limitations": ["Not suitable for scientific inference"]
+            }
+          },
+          "model": {
+            "format": "onnx",
+            "path": "models/protein-seed.onnx",
+            "metadata": {
+              "name": "protein-seed-linear-probe",
+              "version": "fixture-0",
+              "architecture": "linear-probe",
+              "task": "classification",
+              "source": "local-fixture",
+              "description": "Deterministic package fixture model"
+            }
+          },
+          "preprocessing": [],
+          "postprocessing": [],
+          "runtime": {
+            "backend": "onnx-webgpu",
+            "target": "browser-wasm-webgpu",
+            "version": "onnx-webgpu.v0"
+          },
+          "fixtures": [
+            {
+              "name": "tiny-protein",
+              "input": "fixtures/tiny.fasta",
+              "expected_output": "fixtures/tiny.output.json"
+            }
+          ]
+        }"#,
+    )
+    .expect("manifest with model metadata");
+
+    let summary = inspect_package_manifest(&manifest);
+    let metadata = summary.model_metadata.as_ref().expect("model metadata");
+    assert_eq!(metadata.name, "protein-seed-linear-probe");
+    assert_eq!(metadata.version.as_deref(), Some("fixture-0"));
+    assert_eq!(metadata.architecture.as_deref(), Some("linear-probe"));
+    assert_eq!(metadata.task.as_deref(), Some("classification"));
+
+    let report = plan_runtime_bridge(&manifest);
+    assert!(report.ready, "{:?}", report.blocking_issues);
+    assert_eq!(report.model_format, ModelFormat::Onnx);
+    assert_eq!(
+        report
+            .model_metadata
+            .as_ref()
+            .expect("bridge metadata")
+            .name,
+        "protein-seed-linear-probe"
+    );
+    assert!(report.compatibility_checks.iter().any(|check| {
+        check.code == "runtime_model_pair"
+            && check.passed
+            && check
+                .message
+                .contains("onnx-webgpu/browser-wasm-webgpu supports onnx")
+    }));
+}
+
+#[test]
 fn validates_v1_package_layout_and_metadata_contract() {
     let manifest = example_manifest();
     let summary = inspect_package_manifest(&manifest);
@@ -285,8 +364,76 @@ fn plans_supported_onnx_webgpu_runtime_bridge() {
     assert!(report.ready);
     assert_eq!(report.backend, RuntimeBackend::OnnxWebgpu);
     assert_eq!(report.target, RuntimeTargetPlatform::BrowserWasmWebgpu);
+    assert_eq!(report.model_format, ModelFormat::Onnx);
     assert_eq!(report.execution_provider, "webgpu");
+    assert!(report
+        .compatibility_checks
+        .iter()
+        .any(|check| { check.code == "runtime_model_pair" && check.passed }));
     assert!(report.blocking_issues.is_empty());
+}
+
+#[test]
+fn runtime_bridge_rejects_incompatible_model_backend_pair() {
+    let manifest: PackageManifest = serde_json::from_str(
+        r#"{
+          "schema_version": "biors.package.v1",
+          "name": "protein-seed",
+          "package_layout": {
+            "manifest": "manifest.json",
+            "models": "models",
+            "fixtures": "fixtures",
+            "docs": "docs"
+          },
+          "metadata": {
+            "license": { "expression": "CC0-1.0" },
+            "citation": { "preferred_citation": "bio-rs package fixture" },
+            "model_card": {
+              "path": "docs/model-card.md",
+              "summary": "Tiny deterministic package fixture.",
+              "intended_use": ["Validate package tooling"],
+              "limitations": ["Not suitable for scientific inference"]
+            }
+          },
+          "model": {
+            "format": "onnx",
+            "path": "models/protein-seed.onnx",
+            "metadata": {
+              "name": "protein-seed-linear-probe"
+            }
+          },
+          "preprocessing": [],
+          "postprocessing": [],
+          "runtime": {
+            "backend": "candle",
+            "target": "local-cpu",
+            "version": "candle.v0"
+          },
+          "fixtures": [
+            {
+              "name": "tiny-protein",
+              "input": "fixtures/tiny.fasta",
+              "expected_output": "fixtures/tiny.output.json"
+            }
+          ]
+        }"#,
+    )
+    .expect("manifest with incompatible runtime pair");
+
+    let report = plan_runtime_bridge(&manifest);
+
+    assert!(!report.ready);
+    assert_eq!(report.backend, RuntimeBackend::Candle);
+    assert_eq!(report.target, RuntimeTargetPlatform::LocalCpu);
+    assert!(report.blocking_issues.iter().any(|issue| {
+        issue.contains("model format 'onnx'")
+            && issue.contains("backend 'candle'")
+            && issue.contains("target 'local-cpu'")
+    }));
+    assert!(report
+        .compatibility_checks
+        .iter()
+        .any(|check| { check.code == "runtime_model_pair" && !check.passed }));
 }
 
 #[test]

--- a/packages/rust/biors-core/tests/package_validation.rs
+++ b/packages/rust/biors-core/tests/package_validation.rs
@@ -14,6 +14,7 @@ fn minimal_manifest() -> PackageManifest {
             format: ModelFormat::Onnx,
             path: "model.onnx".into(),
             checksum: None,
+            metadata: None,
         },
         tokenizer: None,
         vocab: None,
@@ -43,6 +44,27 @@ fn validate_package_manifest_accepts_minimal_valid_manifest() {
     assert!(report.valid);
     assert!(report.issues.is_empty());
     assert!(report.structured_issues.is_empty());
+}
+
+#[test]
+fn validate_package_manifest_rejects_empty_model_metadata_name() {
+    let mut manifest = minimal_manifest();
+    manifest.model.metadata = Some(biors_core::package::ModelArtifactMetadata {
+        name: " ".into(),
+        version: None,
+        architecture: None,
+        task: None,
+        source: None,
+        description: None,
+    });
+
+    let report = validate_package_manifest(&manifest);
+
+    assert!(!report.valid);
+    assert!(report.structured_issues.iter().any(|issue| {
+        issue.code == PackageValidationIssueCode::RequiredField
+            && issue.field == "model.metadata.name"
+    }));
 }
 
 #[test]

--- a/packages/rust/biors-core/tests/verification.rs
+++ b/packages/rust/biors-core/tests/verification.rs
@@ -16,6 +16,7 @@ fn manifest() -> PackageManifest {
             format: ModelFormat::Onnx,
             path: "models/protein-seed.onnx".to_string(),
             checksum: None,
+            metadata: None,
         },
         tokenizer: None,
         vocab: None,

--- a/packages/rust/biors/src/cli/package_skeleton.rs
+++ b/packages/rust/biors/src/cli/package_skeleton.rs
@@ -110,6 +110,7 @@ pub(crate) fn create_package_skeleton(request: PackageSkeletonRequest) -> Result
             format: ModelFormat::Onnx,
             path: model_rel.clone(),
             checksum: Some(file_sha256(&request.output_dir.join(&model_rel))?),
+            metadata: None,
         },
         tokenizer: Some(tokenizer_asset),
         vocab: None,

--- a/packages/rust/biors/tests/cli_package.rs
+++ b/packages/rust/biors/tests/cli_package.rs
@@ -173,7 +173,17 @@ fn package_bridge_outputs_runtime_plan() {
     assert_eq!(value["data"]["ready"], true);
     assert_eq!(value["data"]["backend"], "onnx-webgpu");
     assert_eq!(value["data"]["target"], "browser-wasm-webgpu");
+    assert_eq!(value["data"]["model_format"], "onnx");
+    assert_eq!(
+        value["data"]["model_metadata"]["name"],
+        "protein-seed-linear-probe"
+    );
     assert_eq!(value["data"]["execution_provider"], "webgpu");
+    assert_eq!(
+        value["data"]["compatibility_checks"][0]["code"],
+        "runtime_model_pair"
+    );
+    assert_eq!(value["data"]["compatibility_checks"][0]["passed"], true);
     assert_eq!(
         value["data"]["blocking_issues"]
             .as_array()

--- a/schemas/package-bridge-output.v0.json
+++ b/schemas/package-bridge-output.v0.json
@@ -3,13 +3,54 @@
   "$id": "https://bio-rs.dev/schemas/package-bridge-output.v0.json",
   "title": "bio-rs package bridge data payload",
   "type": "object",
-  "required": ["ready", "backend", "target", "execution_provider", "blocking_issues"],
+  "required": [
+    "ready",
+    "backend",
+    "target",
+    "model_format",
+    "model_metadata",
+    "execution_provider",
+    "compatibility_checks",
+    "blocking_issues"
+  ],
   "properties": {
     "ready": { "type": "boolean" },
     "backend": { "type": "string" },
     "target": { "type": "string" },
+    "model_format": { "type": "string" },
+    "model_metadata": { "$ref": "#/$defs/modelArtifactMetadata" },
     "execution_provider": { "type": "string" },
+    "compatibility_checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/compatibilityCheck" }
+    },
     "blocking_issues": { "type": "array", "items": { "type": "string" } }
+  },
+  "$defs": {
+    "modelArtifactMetadata": {
+      "type": ["object", "null"],
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": ["string", "null"] },
+        "architecture": { "type": ["string", "null"] },
+        "task": { "type": ["string", "null"] },
+        "source": { "type": ["string", "null"] },
+        "description": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
+    "compatibilityCheck": {
+      "type": "object",
+      "required": ["code", "passed", "message"],
+      "properties": {
+        "code": { "type": "string", "minLength": 1 },
+        "passed": { "type": "boolean" },
+        "message": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    }
   },
   "additionalProperties": false
 }

--- a/schemas/package-inspect-output.v0.json
+++ b/schemas/package-inspect-output.v0.json
@@ -10,6 +10,7 @@
     "metadata",
     "model_format",
     "has_model_checksum",
+    "model_metadata",
     "runtime_backend",
     "runtime_target",
     "preprocessing_steps",
@@ -47,6 +48,19 @@
     },
     "model_format": { "type": "string" },
     "has_model_checksum": { "type": "boolean" },
+    "model_metadata": {
+      "type": ["object", "null"],
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": ["string", "null"] },
+        "architecture": { "type": ["string", "null"] },
+        "task": { "type": ["string", "null"] },
+        "source": { "type": ["string", "null"] },
+        "description": { "type": ["string", "null"] }
+      },
+      "additionalProperties": false
+    },
     "tokenizer": { "type": ["string", "null"] },
     "vocab": { "type": ["string", "null"] },
     "runtime_backend": { "type": "string" },

--- a/schemas/package-manifest.v0.json
+++ b/schemas/package-manifest.v0.json
@@ -16,8 +16,8 @@
       "type": "object",
       "required": ["backend", "target"],
       "properties": {
-        "backend": { "const": "onnx-webgpu" },
-        "target": { "const": "browser-wasm-webgpu" }
+        "backend": { "enum": ["onnx-webgpu", "candle"] },
+        "target": { "enum": ["browser-wasm-webgpu", "local-cpu"] }
       },
       "additionalProperties": false
     },
@@ -31,9 +31,23 @@
       "type": "object",
       "required": ["format", "path"],
       "properties": {
-        "format": { "const": "onnx" },
+        "format": { "enum": ["onnx", "safetensors"] },
         "path": { "type": "string", "minLength": 1 },
-        "checksum": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+        "checksum": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "metadata": { "$ref": "#/$defs/modelArtifactMetadata" }
+      },
+      "additionalProperties": false
+    },
+    "modelArtifactMetadata": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "architecture": { "type": "string", "minLength": 1 },
+        "task": { "type": "string", "minLength": 1 },
+        "source": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 }
       },
       "additionalProperties": false
     },

--- a/schemas/package-manifest.v1.json
+++ b/schemas/package-manifest.v1.json
@@ -28,8 +28,8 @@
       "type": "object",
       "required": ["backend", "target"],
       "properties": {
-        "backend": { "const": "onnx-webgpu" },
-        "target": { "const": "browser-wasm-webgpu" },
+        "backend": { "enum": ["onnx-webgpu", "candle"] },
+        "target": { "enum": ["browser-wasm-webgpu", "local-cpu"] },
         "version": { "type": "string", "minLength": 1 }
       },
       "additionalProperties": false
@@ -114,9 +114,23 @@
       "type": "object",
       "required": ["format", "path"],
       "properties": {
-        "format": { "const": "onnx" },
+        "format": { "enum": ["onnx", "safetensors"] },
         "path": { "type": "string", "minLength": 1 },
-        "checksum": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+        "checksum": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "metadata": { "$ref": "#/$defs/modelArtifactMetadata" }
+      },
+      "additionalProperties": false
+    },
+    "modelArtifactMetadata": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "architecture": { "type": "string", "minLength": 1 },
+        "task": { "type": "string", "minLength": 1 },
+        "source": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
## Summary
- add optional model artifact metadata to package manifests and inspect/bridge outputs
- add runtime/model compatibility checks for ONNX WebGPU and safetensors Candle CPU planning pairs
- surface incompatible model/backend/target combinations as bridge blocking issues
- update schemas, example package metadata, and package/backend docs
- prepare workspace/docs for v0.41.0

## Verification
- RED: `cargo test -p biors-core --test package` failed on missing 0.41 report fields and variants
- RED: `cargo test -p biors-core --test package_validation validate_package_manifest_rejects_empty_model_metadata_name` failed while empty metadata names were accepted
- `cargo test -p biors-core --test package`
- `cargo test -p biors-core --test package_validation`
- `cargo test -p biors --test cli_package package_bridge_outputs_runtime_plan`
- `cargo test -p biors --test schema_contract`
- `scripts/check-fast.sh`
- `scripts/check.sh` at feature state
- `scripts/check.sh` at v0.41.0 release-prep state
- pre-push hook reran the full check gate during `git push`