### PR TITLE
Refactor project architecture and cleanup slop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,108 +1,127 @@
-# AGENTS.md
+# PROJECT KNOWLEDGE BASE
 
-## Role
+**Generated:** 2026-06-05T20:45:07Z
+**Commit:** 2595486
+**Branch:** chore/init-deep-agents
 
-Work as an autonomous coding agent for bio-rs.
+## OVERVIEW
 
-bio-rs is an open-source Rust project for biological AI tooling infrastructure. Keep changes small, inspectable, reproducible, dependency-light, and honest about what is implemented.
+bio-rs is a Rust workspace for biological AI tooling infrastructure: core
+validation/conversion logic, a CLI, optional backend adapters, MCP service
+tools, Python bindings, and WASM/npm bindings. GitHub code plus checked-in
+tests, schemas, contracts, and fixtures are the source of truth.
 
-## Source of Truth
+## STRUCTURE
 
-GitHub code is the implementation source of truth.
+```text
+bio-rs/
+|-- crates/      # workspace crates and binding surfaces
+|-- docs/        # public docs for implemented behavior and contracts
+|-- schemas/     # JSON Schema contracts for CLI/API outputs and package data
+|-- contracts/   # small checked-in reference contracts
+|-- testdata/    # end-to-end package, pipeline, and sequence fixtures
+|-- scripts/     # local gates, release checks, benchmark tooling
+|-- .github/     # CI, benchmark, and release workflows
+|-- benchmarks/  # committed benchmark regression artifacts and reports
+`-- deploy/      # local deployment templates only
+```
 
-Planning notes, roadmap text, issues, README copy, and release ideas are direction unless the behavior is implemented, tested, and documented.
+## WHERE TO LOOK
 
-Before changing behavior, inspect the relevant code and existing repo docs:
+| Task | Location | Notes |
+| --- | --- | --- |
+| Core APIs, parsing, validation | `crates/biors-core` | Deterministic, dependency-light domain logic |
+| CLI behavior | `crates/biors` | Command routing, JSON envelopes, service command |
+| Python bindings | `crates/biors-python` | PyO3 plus maturin packaging |
+| WASM/npm bindings | `crates/biors-wasm` | wasm-bindgen plus npm packaging |
+| MCP server | `crates/biors-mcp-server` | Tool routing separate from CLI |
+| Optional Candle backend | `crates/biors-backend-candle` | Adapter crate; do not pull backend weight into core |
+| Public docs | `docs/` | Describe implemented behavior only |
+| JSON schemas | `schemas/` | Public output/package/service contracts |
+| Fixtures | `testdata/`, `crates/*/tests/fixtures` | Repo-level end-to-end data vs crate-local focused data |
+| Release and CI gates | `scripts/`, `.github/workflows/` | Scripts are the executable policy |
 
-- `README.md`
-- `CONTRIBUTING.md`
-- `docs/`
-- `schemas/`
-- `contracts/`
-- `testdata/`
-- `integrations/`
-- `deploy/`
-- `.github/`
-- `scripts/check.sh`
+## CONVENTIONS
 
-Do not duplicate detailed contracts here.
+- Source of truth order: implementation and tests first, then schemas,
+  contracts, fixtures, docs, README, roadmap text.
+- Keep implementation, tests, test data, schemas, contracts, docs, and
+  integration templates aligned whenever behavior changes.
+- Do not claim roadmap or "not yet" items as current features.
+- Workspace crates ship in lockstep pre-1.0; docs-only changes do not require a
+  version bump, but public contract changes usually do.
+- Keep `biors-core` deterministic and dependency-light; CLI, bindings,
+  packaging, runtime adapters, and integration logic belong outside core unless
+  a shared contract requires core ownership.
+- Local-first and privacy-first defaults matter: no network, telemetry,
+  uploads, external model calls, hosted workspace behavior, or persistence
+  unless explicitly requested and documented.
+- Benchmark reports are scoped regression guardrails. Do not turn them into
+  broad performance claims without fresh workload-specific evidence.
+- Package paths must stay package-relative. Reject absolute paths, `..`
+  traversal, missing files, checksum mismatches, and unknown schema versions
+  with stable errors.
 
-Keep implementation, tests, test data, schemas, contracts, docs, and integration templates aligned.
+## AUTONOMY
 
-Do not claim roadmap items as current features.
+- Work without asking for routine decisions when the repository can be
+  inspected.
+- Do not ask the user to choose branch names, commit messages, file paths, or
+  task splits.
+- Ask only when the task is destructive, requires secrets, intentionally breaks
+  public behavior, or is genuinely ambiguous in a user-facing way.
+- When unsure, choose the smallest safe change that preserves current behavior.
 
-## Autonomy
+## ANTI-PATTERNS
 
-Work without asking for routine decisions.
+- Broad rewrites, speculative abstractions, hidden global state, and optional
+  heavy dependencies in shared code.
+- Generated artifacts, caches, wheels, npm package output, `target/`, local
+  virtualenvs, logs, secrets, or internal audit notes in commits.
+- Editing release metadata by blind text replacement when a tool can regenerate
+  it safely.
+- Public docs that overstate DNA/RNA, hosted, browser, service, benchmark, or
+  model-execution support beyond what code and tests enforce.
 
-Do not ask the user to choose branch names, commit messages, file paths, or task splits when the repository can be inspected.
+## COMMANDS
 
-Ask only when the task is destructive, requires secrets, intentionally breaks public behavior, or is genuinely ambiguous in a way that changes user-facing behavior.
+```bash
+scripts/check-fast.sh
+scripts/check.sh
+scripts/check-final-release.sh
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+```
 
-When unsure, choose the smallest safe change that preserves current behavior.
+## SHIPPING
 
-## Repository Safety
+- Before editing or committing, inspect branch and working tree.
+- Stage only intended files; preserve unrelated user work.
+- Use the local repo-shipping workflow for commits, pushes, releases, and
+  deployment safety.
+- Commits and pushes may proceed when explicitly requested and safe.
+- Tags, releases, registry publishing, deployment, and version bumps need
+  explicit user approval immediately before execution.
+- For release-affecting work, `scripts/check-final-release.sh` is the local
+  source of truth before pushing a tag.
 
-Before editing or committing, inspect the current branch and working tree.
+## QUALITY
 
-Do not overwrite unrelated user changes.
+- Run `scripts/check.sh` when behavior, release, or cross-surface contracts
+  change.
+- For docs-only or instruction-only changes, code checks are not required unless
+  the text describes changed behavior.
+- If a relevant check cannot be run, state why.
 
-Do not stage unrelated files.
+## SECURITY
 
-Do not commit generated artifacts, caches, logs, build outputs, temporary files, or `target/`.
+- Keep vulnerability reports private.
+- Do not upload biological data, model inputs, package artifacts, or user
+  content to external services by default.
+- Do not commit credentials, private URLs, telemetry, analytics, or external
+  reporting hooks.
 
-If generated or local-only files appear and are not ignored, update `.gitignore` in a separate logical commit when appropriate.
+## FINAL SUMMARY
 
-## Architecture
-
-Keep reusable domain logic separate from CLI, bindings, packaging, runtime, and integration layers.
-
-Keep core behavior deterministic, testable, and dependency-light.
-
-Write code with Clean Code and SOLID discipline, especially single responsibility.
-
-Each file, module, type, and function should have one clear reason to change.
-
-Split code by logical responsibility before files become hard to scan; external contributors should be able to infer the design from module names and small, focused files.
-
-Make heavy, platform-specific, experimental, or integration-oriented capabilities optional or isolated.
-
-Prefer clear module boundaries before adding crates.
-
-Avoid speculative abstractions, global state, large rewrites, and unnecessary dependencies.
-
-## Quality
-
-Use the repository’s existing checks and CI conventions.
-
-Run `scripts/check.sh` when relevant.
-
-Add or update tests, fixtures, schemas, docs, and examples when behavior changes.
-
-For docs-only changes, code checks are not required unless the docs describe changed behavior.
-
-If a check cannot be run, state why.
-
-## Shipping
-
-For commit, push, release, publish, deploy, versioning, or shipping-safety work, use the repo-shipping workflow.
-
-Commits and pushes may proceed when explicitly requested and safe.
-
-Releases, package publishing, tags, deploys, and version bumps require explicit user approval immediately before execution.
-
-Do not bump versions, create tags, publish packages, deploy, or mark work as released unless the user clearly confirms that exact action.
-
-Do not make benchmark or performance claims without reproducible evidence.
-
-## Security
-
-Do not commit secrets, credentials, private URLs, local env files, telemetry, analytics, or external reporting.
-
-Do not upload biological data or user content to external services unless explicitly requested and documented.
-
-## Final Summary
-
-When finished, report what changed, checks run, public behavior changes, docs updated, and follow-up work left out.
-
-Do not claim work was completed unless it was actually completed.
+Report changed files, checks run, public behavior changes, docs updated, and
+anything intentionally left out. Do not claim completion without verification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,5 @@
 # PROJECT KNOWLEDGE BASE
 
-**Generated:** 2026-06-05T20:45:07Z
-**Commit:** 2595486
-**Branch:** chore/init-deep-agents
-
 ## OVERVIEW
 
 bio-rs is a Rust workspace for biological AI tooling infrastructure: core

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -1,0 +1,67 @@
+# CRATES KNOWLEDGE BASE
+
+## OVERVIEW
+
+`crates/` is a Cargo workspace with thin public surfaces around shared
+biological domain logic.
+
+## STRUCTURE
+
+```text
+crates/
+|-- biors-core/            # shared domain contracts and validation logic
+|-- biors/                 # CLI binary and local service command
+|-- biors-python/          # PyO3/maturin binding package
+|-- biors-wasm/            # wasm-bindgen/npm binding package
+|-- biors-mcp-server/      # MCP tool server
+`-- biors-backend-candle/  # optional Candle backend adapter
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Shared records, validators, parsers | `biors-core/src` | Keep reusable and non-CLI-specific |
+| CLI command behavior | `biors/src/cli` | Mirrors `docs/cli-contract.md` and `schemas/` |
+| CLI contract tests | `biors/tests` | One concern per integration test file |
+| Python API | `biors-python/src`, `biors-python/python/biors` | Rust wrappers plus typed Python surface |
+| WASM API | `biors-wasm/src`, `biors-wasm/index.d.ts` | JS/WASM boundary and TS declarations |
+| MCP tools | `biors-mcp-server/src` | Server/tool routing outside CLI |
+| Backend adapter | `biors-backend-candle/src` | Optional runtime bridge only |
+
+## CONVENTIONS
+
+- Keep crate ownership clear. Move shared biological contracts into
+  `biors-core`; keep command parsing, output formatting, packaging CLIs,
+  Python-specific wrappers, WASM-specific wrappers, and MCP transport code in
+  their surface crates.
+- Do not introduce a dependency into `biors-core` just because a surface crate
+  needs it.
+- Workspace package metadata is centralized at the root `Cargo.toml`; avoid
+  local drift unless a crate truly has surface-specific packaging metadata.
+- Binding crates must preserve parity with core behavior and CLI schemas where
+  their API claims the same capability.
+- Optional backend crates should report capability/error boundaries without
+  changing core contracts.
+
+## CHECKS
+
+```bash
+cargo test -p biors-core
+cargo test -p biors
+cargo test -p biors-mcp-server --all-targets
+maturin build --manifest-path crates/biors-python/Cargo.toml
+wasm-pack test --node crates/biors-wasm
+```
+
+Use the surface-specific command only when that surface changes; run root gates
+for cross-crate or release-facing work.
+
+## ANTI-PATTERNS
+
+- Duplicating parser, validation, schema, or package rules across surface
+  crates instead of sharing a core contract.
+- Letting Python, WASM, MCP, or Candle behavior silently diverge from core
+  validation semantics.
+- Treating package metadata files as generated throwaways; they are published
+  surfaces.

--- a/crates/biors-core/AGENTS.md
+++ b/crates/biors-core/AGENTS.md
@@ -1,0 +1,68 @@
+# BIORS-CORE KNOWLEDGE BASE
+
+## OVERVIEW
+
+`biors-core` owns deterministic biological records, parsers, validators,
+package/runtime contracts, reports, and model-ready input mapping.
+
+## STRUCTURE
+
+```text
+src/
+|-- fasta*.rs       # FASTA parsing, validation, inspection, streaming scan
+|-- formats/        # FASTQ and shared format records/capabilities
+|-- sequence/       # sequence kind, normalization, residue validation
+|-- molecule/       # SMILES/SDF/MOL2 records, graph, validation, features
+|-- structure/      # PDB records, coordinates, residue handling
+|-- package/        # package manifests, layout, validation, artifacts
+|-- runtime/        # runtime contracts and external-process bridge
+|-- verification/   # fixture verification, diffs, hashes
+|-- reports/        # JSON-to-human report assembly
+`-- templates/      # task template definitions
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Public exports | `src/lib.rs` | Keep surface explicit |
+| Package validation | `src/package/validation*`, `tests/package_*` | Issue codes and path rules are contract behavior |
+| Fixture verification | `src/verification/`, `tests/fixture_contract.rs` | Hashes and output comparison must be reproducible |
+| Format parsers | `src/formats`, `src/fasta*` | Preserve diagnostics and record positions |
+| Molecule/structure support | `src/molecule`, `src/structure` | Conservative validation over optimistic inference |
+| Runtime bridge | `src/runtime`, `tests/runtime*` | No hidden process/network behavior |
+
+## CONVENTIONS
+
+- Keep code deterministic, side-effect-light, and usable from CLI, Python,
+  WASM, MCP, and service surfaces.
+- Use structured error types and stable issue/error codes when behavior crosses
+  a public boundary.
+- Package and pipeline validators must reject ambiguous paths, unknown schema
+  versions, missing artifacts, checksum mismatches, and layout escapes.
+- Fixtures in `tests/fixtures/` are crate-local; use root `testdata/` for
+  end-to-end package or CLI fixtures.
+- Prefer small modules by biological responsibility. Split before files become
+  mixed parser/validator/renderer/tooling units.
+- Do not use network access, filesystem writes outside explicit validation
+  targets, clocks, randomness, or global mutable state in core logic unless a
+  public contract requires it.
+
+## CHECKS
+
+```bash
+cargo test -p biors-core
+cargo check -p biors-core --target wasm32-unknown-unknown
+cargo clippy -p biors-core --all-targets -- -D warnings
+```
+
+For package, runtime, or fixture contract changes, add the focused integration
+test first, then run the root fast gate.
+
+## ANTI-PATTERNS
+
+- CLI formatting, Python class ergonomics, WASM serialization quirks, or MCP
+  transport details inside core.
+- Permissive parsing that drops diagnostics, positions, chain/residue identity,
+  molecule bond context, or provenance needed by researchers.
+- Future-facing feature names without implemented validation and tests.

--- a/crates/biors-core/src/workflow.rs
+++ b/crates/biors-core/src/workflow.rs
@@ -2,10 +2,7 @@ use crate::model_input::{
     build_model_inputs_checked, validate_model_input_policy, ModelInput, ModelInputBuildError,
     ModelInputPolicy,
 };
-use crate::sequence::{
-    validate_sequence_record, ProteinSequence, ResidueIssue, SequenceKind, SequenceRecord,
-    SequenceValidationIssue, SequenceValidationReport, ValidatedSequence,
-};
+use crate::sequence::{ProteinSequence, SequenceValidationReport};
 use crate::tokenizer::{
     protein_tokenizer_config_for_profile, summarize_tokenized_proteins,
     tokenize_protein_with_config, ProteinBatchSummary, ProteinTokenizerConfig,
@@ -13,9 +10,15 @@ use crate::tokenizer::{
 };
 use serde::{Deserialize, Serialize};
 
+mod provenance;
+mod readiness;
 mod reproducibility;
+mod validation;
+use provenance::{workflow_name, workflow_provenance};
+use readiness::readiness_issues;
 use reproducibility::{workflow_hashes, WorkflowHashInput, CORE_WORKFLOW_COMMAND};
 pub use reproducibility::{SequenceWorkflowHashes, SequenceWorkflowInvocation};
+use validation::{validate_records_for_profile, validate_workflow_input_hash};
 
 const PROTEIN_WORKFLOW_NAME: &str = "protein_model_input.v0";
 const SEQUENCE_WORKFLOW_NAME: &str = "sequence_model_input.v0";
@@ -149,127 +152,10 @@ pub fn prepare_model_input_workflow_with_config(
     Ok(SequenceWorkflowOutput {
         workflow: workflow.to_string(),
         model_ready,
-        provenance: provenance(input_hash, policy, invocation, hashes, config.profile),
+        provenance: workflow_provenance(input_hash, policy, invocation, hashes, config.profile),
         validation,
         tokenization,
         model_input,
         readiness_issues,
     })
-}
-
-fn validate_records_for_profile(
-    records: &[ProteinSequence],
-    profile: ProteinTokenizerProfile,
-) -> SequenceValidationReport {
-    let kind = profile.sequence_kind();
-    let sequences = records
-        .iter()
-        .map(|record| {
-            let validation = validate_sequence_record(&SequenceRecord {
-                id: record.id.clone(),
-                sequence: String::from_utf8_lossy(&record.sequence).into_owned(),
-                kind,
-            });
-            ValidatedSequence {
-                id: validation.id,
-                sequence: validation.sequence,
-                alphabet: validation.alphabet,
-                valid: validation.valid,
-                warnings: validation
-                    .warnings
-                    .into_iter()
-                    .map(issue_to_residue_issue)
-                    .collect(),
-                errors: validation
-                    .errors
-                    .into_iter()
-                    .map(issue_to_residue_issue)
-                    .collect(),
-            }
-        })
-        .collect();
-    crate::sequence::summarize_validated_sequences(sequences)
-}
-
-fn issue_to_residue_issue(issue: SequenceValidationIssue) -> ResidueIssue {
-    ResidueIssue {
-        residue: issue.symbol,
-        position: issue.position,
-    }
-}
-
-fn validate_workflow_input_hash(input_hash: &str) -> Result<(), ModelInputBuildError> {
-    if crate::verification::is_stable_input_hash(input_hash) {
-        Ok(())
-    } else {
-        Err(ModelInputBuildError::InvalidInputHash {
-            input_hash: input_hash.to_string(),
-        })
-    }
-}
-
-fn provenance(
-    input_hash: String,
-    policy: ModelInputPolicy,
-    invocation: SequenceWorkflowInvocation,
-    hashes: SequenceWorkflowHashes,
-    profile: ProteinTokenizerProfile,
-) -> SequenceWorkflowProvenance {
-    let vocab = crate::tokenizer::inspect_protein_tokenizer_config(
-        &protein_tokenizer_config_for_profile(profile),
-    )
-    .vocabulary;
-    SequenceWorkflowProvenance {
-        biors_core_version: env!("CARGO_PKG_VERSION").to_string(),
-        invocation,
-        input_hash,
-        normalization: NORMALIZATION_POLICY.to_string(),
-        validation_alphabet: vocab.name.clone(),
-        tokenizer: WorkflowTokenizerMetadata {
-            name: vocab.name.clone(),
-            vocab_size: vocab.tokens.len(),
-            unknown_token_id: vocab.unknown_token_id,
-            unknown_token_policy: vocab.unknown_token_policy.clone(),
-        },
-        model_input_policy: policy,
-        hashes,
-    }
-}
-
-fn workflow_name(profile: ProteinTokenizerProfile) -> &'static str {
-    match profile.sequence_kind() {
-        SequenceKind::Protein => PROTEIN_WORKFLOW_NAME,
-        SequenceKind::Dna | SequenceKind::Rna => SEQUENCE_WORKFLOW_NAME,
-    }
-}
-
-fn readiness_issues(tokenized: &[TokenizedProtein]) -> Vec<SequenceWorkflowReadinessIssue> {
-    tokenized
-        .iter()
-        .filter(|record| {
-            record.tokens.is_empty() || !record.warnings.is_empty() || !record.errors.is_empty()
-        })
-        .map(|record| {
-            let warning_count = record.warnings.len();
-            let error_count = record.errors.len();
-            let message = if record.tokens.is_empty() {
-                format!(
-                    "sequence '{}' is not model-ready: empty sequences cannot be converted into model input",
-                    record.id
-                )
-            } else {
-                format!(
-                    "sequence '{}' is not model-ready: {warning_count} warnings and {error_count} errors must be resolved before model-input generation",
-                    record.id
-                )
-            };
-            SequenceWorkflowReadinessIssue {
-                code: READINESS_ISSUE_CODE.to_string(),
-                id: record.id.clone(),
-                warning_count,
-                error_count,
-                message,
-            }
-        })
-        .collect()
 }

--- a/crates/biors-core/src/workflow.rs
+++ b/crates/biors-core/src/workflow.rs
@@ -126,7 +126,8 @@ pub fn prepare_model_input_workflow_with_config(
         .map(|record| tokenize_protein_with_config(record, &config))
         .collect();
     let readiness_issues = readiness_issues(&tokenized);
-    let model_input = if readiness_issues.is_empty() {
+    let model_ready = readiness_issues.is_empty();
+    let model_input = if model_ready {
         Some(build_model_inputs_checked(&tokenized, policy.clone())?)
     } else {
         None
@@ -135,7 +136,6 @@ pub fn prepare_model_input_workflow_with_config(
         summary: summarize_tokenized_proteins(&tokenized),
         records: tokenized,
     };
-    let model_ready = readiness_issues.is_empty();
     let workflow = workflow_name(config.profile);
     let hashes = workflow_hashes(WorkflowHashInput {
         workflow,

--- a/crates/biors-core/src/workflow/provenance.rs
+++ b/crates/biors-core/src/workflow/provenance.rs
@@ -1,0 +1,42 @@
+use super::{
+    SequenceWorkflowHashes, SequenceWorkflowInvocation, SequenceWorkflowProvenance,
+    WorkflowTokenizerMetadata, NORMALIZATION_POLICY, PROTEIN_WORKFLOW_NAME, SEQUENCE_WORKFLOW_NAME,
+};
+use crate::model_input::ModelInputPolicy;
+use crate::sequence::SequenceKind;
+use crate::tokenizer::{
+    inspect_protein_tokenizer_config, protein_tokenizer_config_for_profile, ProteinTokenizerProfile,
+};
+
+pub(super) fn workflow_provenance(
+    input_hash: String,
+    policy: ModelInputPolicy,
+    invocation: SequenceWorkflowInvocation,
+    hashes: SequenceWorkflowHashes,
+    profile: ProteinTokenizerProfile,
+) -> SequenceWorkflowProvenance {
+    let vocab =
+        inspect_protein_tokenizer_config(&protein_tokenizer_config_for_profile(profile)).vocabulary;
+    SequenceWorkflowProvenance {
+        biors_core_version: env!("CARGO_PKG_VERSION").to_string(),
+        invocation,
+        input_hash,
+        normalization: NORMALIZATION_POLICY.to_string(),
+        validation_alphabet: vocab.name.clone(),
+        tokenizer: WorkflowTokenizerMetadata {
+            name: vocab.name.clone(),
+            vocab_size: vocab.tokens.len(),
+            unknown_token_id: vocab.unknown_token_id,
+            unknown_token_policy: vocab.unknown_token_policy.clone(),
+        },
+        model_input_policy: policy,
+        hashes,
+    }
+}
+
+pub(super) fn workflow_name(profile: ProteinTokenizerProfile) -> &'static str {
+    match profile.sequence_kind() {
+        SequenceKind::Protein => PROTEIN_WORKFLOW_NAME,
+        SequenceKind::Dna | SequenceKind::Rna => SEQUENCE_WORKFLOW_NAME,
+    }
+}

--- a/crates/biors-core/src/workflow/provenance.rs
+++ b/crates/biors-core/src/workflow/provenance.rs
@@ -15,16 +15,17 @@ pub(super) fn workflow_provenance(
     hashes: SequenceWorkflowHashes,
     profile: ProteinTokenizerProfile,
 ) -> SequenceWorkflowProvenance {
-    let vocab =
-        inspect_protein_tokenizer_config(&protein_tokenizer_config_for_profile(profile)).vocabulary;
+    let config = protein_tokenizer_config_for_profile(profile);
+    let vocab = inspect_protein_tokenizer_config(&config).vocabulary;
+    let vocab_name = vocab.name.clone();
     SequenceWorkflowProvenance {
         biors_core_version: env!("CARGO_PKG_VERSION").to_string(),
         invocation,
         input_hash,
         normalization: NORMALIZATION_POLICY.to_string(),
-        validation_alphabet: vocab.name.clone(),
+        validation_alphabet: vocab_name.clone(),
         tokenizer: WorkflowTokenizerMetadata {
-            name: vocab.name.clone(),
+            name: vocab_name,
             vocab_size: vocab.tokens.len(),
             unknown_token_id: vocab.unknown_token_id,
             unknown_token_policy: vocab.unknown_token_policy.clone(),

--- a/crates/biors-core/src/workflow/readiness.rs
+++ b/crates/biors-core/src/workflow/readiness.rs
@@ -1,0 +1,35 @@
+use super::{SequenceWorkflowReadinessIssue, READINESS_ISSUE_CODE};
+use crate::tokenizer::TokenizedProtein;
+
+pub(super) fn readiness_issues(
+    tokenized: &[TokenizedProtein],
+) -> Vec<SequenceWorkflowReadinessIssue> {
+    tokenized
+        .iter()
+        .filter(|record| {
+            record.tokens.is_empty() || !record.warnings.is_empty() || !record.errors.is_empty()
+        })
+        .map(|record| {
+            let warning_count = record.warnings.len();
+            let error_count = record.errors.len();
+            let message = if record.tokens.is_empty() {
+                format!(
+                    "sequence '{}' is not model-ready: empty sequences cannot be converted into model input",
+                    record.id
+                )
+            } else {
+                format!(
+                    "sequence '{}' is not model-ready: {warning_count} warnings and {error_count} errors must be resolved before model-input generation",
+                    record.id
+                )
+            };
+            SequenceWorkflowReadinessIssue {
+                code: READINESS_ISSUE_CODE.to_string(),
+                id: record.id.clone(),
+                warning_count,
+                error_count,
+                message,
+            }
+        })
+        .collect()
+}

--- a/crates/biors-core/src/workflow/validation.rs
+++ b/crates/biors-core/src/workflow/validation.rs
@@ -1,0 +1,57 @@
+use crate::model_input::ModelInputBuildError;
+use crate::sequence::{
+    validate_sequence_record, ProteinSequence, ResidueIssue, SequenceRecord,
+    SequenceValidationIssue, SequenceValidationReport, ValidatedSequence,
+};
+use crate::tokenizer::ProteinTokenizerProfile;
+
+pub(super) fn validate_records_for_profile(
+    records: &[ProteinSequence],
+    profile: ProteinTokenizerProfile,
+) -> SequenceValidationReport {
+    let kind = profile.sequence_kind();
+    let sequences = records
+        .iter()
+        .map(|record| {
+            let validation = validate_sequence_record(&SequenceRecord {
+                id: record.id.clone(),
+                sequence: String::from_utf8_lossy(&record.sequence).into_owned(),
+                kind,
+            });
+            ValidatedSequence {
+                id: validation.id,
+                sequence: validation.sequence,
+                alphabet: validation.alphabet,
+                valid: validation.valid,
+                warnings: validation
+                    .warnings
+                    .into_iter()
+                    .map(issue_to_residue_issue)
+                    .collect(),
+                errors: validation
+                    .errors
+                    .into_iter()
+                    .map(issue_to_residue_issue)
+                    .collect(),
+            }
+        })
+        .collect();
+    crate::sequence::summarize_validated_sequences(sequences)
+}
+
+pub(super) fn validate_workflow_input_hash(input_hash: &str) -> Result<(), ModelInputBuildError> {
+    if crate::verification::is_stable_input_hash(input_hash) {
+        Ok(())
+    } else {
+        Err(ModelInputBuildError::InvalidInputHash {
+            input_hash: input_hash.to_string(),
+        })
+    }
+}
+
+fn issue_to_residue_issue(issue: SequenceValidationIssue) -> ResidueIssue {
+    ResidueIssue {
+        residue: issue.symbol,
+        position: issue.position,
+    }
+}

--- a/crates/biors-mcp-server/src/profile.rs
+++ b/crates/biors-mcp-server/src/profile.rs
@@ -50,15 +50,17 @@ pub(crate) fn workflow_profile(
         None => default_profile(kind, &report)?,
     };
 
-    if kind != "auto" && profile.sequence_kind() != selection.explicit_kind().unwrap() {
-        return Err(McpError::invalid_params(
-            "workflow kind/profile mismatch",
-            Some(serde_json::json!({
-                "kind": kind,
-                "profile": profile.as_str(),
-                "message": "workflow kind must match tokenizer profile sequence kind"
-            })),
-        ));
+    if let Some(expected_kind) = selection.explicit_kind() {
+        if profile.sequence_kind() != expected_kind {
+            return Err(McpError::invalid_params(
+                "workflow kind/profile mismatch",
+                Some(serde_json::json!({
+                    "kind": kind,
+                    "profile": profile.as_str(),
+                    "message": "workflow kind must match tokenizer profile sequence kind"
+                })),
+            ));
+        }
     }
 
     Ok(profile)

--- a/crates/biors/AGENTS.md
+++ b/crates/biors/AGENTS.md
@@ -1,0 +1,63 @@
+# CLI CRATE KNOWLEDGE BASE
+
+## OVERVIEW
+
+`crates/biors` owns the `biors` binary, command parsing, CLI JSON envelopes,
+local service command, package tooling commands, and release/readiness tests.
+
+## STRUCTURE
+
+```text
+src/
+|-- main.rs          # binary entry
+|-- cli/mod.rs      # command dispatcher
+|-- cli/*_args.rs   # clap argument definitions
+|-- cli/*           # command handlers and output assembly
+|-- input/          # file/stdin/input-source handling
+`-- output.rs       # CLI output envelope helpers
+tests/
+|-- cli_*.rs        # user-facing command behavior
+|-- schema_*.rs     # schema contract coverage
+`-- release_*.rs    # release/readiness policy assertions
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Command shape | `src/cli/args.rs`, `src/cli/*_args.rs` | Keep in sync with `docs/cli-contract.md` |
+| Command handlers | `src/cli/handlers.rs`, `src/cli/*.rs` | Keep JSON output schema-backed |
+| Service command | `src/cli/serve*.rs`, `src/cli/service_args.rs` | Local-first HTTP surface |
+| Package commands | `src/cli/package*` | Must preserve package layout and checksums |
+| Dataset/batch input resolution | `src/input`, `src/cli/dataset`, `src/cli/batch.rs` | File, directory, stdin, and glob behavior |
+
+## CONVENTIONS
+
+- Treat `docs/cli-contract.md` and `schemas/*.json` as the public CLI contract.
+  Change code, tests, docs, and schema together.
+- CLI stdout is for the documented output envelope. Keep diagnostics and human
+  guidance on stderr unless a schema says otherwise.
+- `biors serve` remains local-first: default `127.0.0.1:8787`, no network
+  uploads, no hosted workspace behavior, and no external model calls.
+- Integration tests should use repo fixtures and shared helpers instead of
+  shelling out through ad hoc temp layouts.
+- Release policy tests are deliberate guardrails. Update them only when the
+  release process or supported surface actually changes.
+
+## CHECKS
+
+```bash
+cargo test -p biors
+cargo test -p biors --test schema_contract --test schema_cli_package_contract
+scripts/check-fast.sh
+```
+
+Run schema and release tests for changes that affect CLI JSON, docs inventory,
+release workflow assumptions, or packaging commands.
+
+## ANTI-PATTERNS
+
+- Adding a CLI command without schema coverage, docs coverage, and a fixture or
+  integration test for expected researcher-facing behavior.
+- Hiding validation failures behind generic exit messages.
+- Treating service mode as hosted infrastructure.

--- a/crates/biors/src/cli/batch.rs
+++ b/crates/biors/src/cli/batch.rs
@@ -1,6 +1,6 @@
 use super::{BatchCommand, KindArg};
 use crate::errors::CliError;
-use crate::input::{open_fasta_input, resolve_fasta_input_dataset_with_glob_code};
+use crate::input::{open_buffered_input, resolve_fasta_input_dataset_with_glob_code};
 use crate::output::print_success;
 use biors_core::sequence::kind_validation::validate_fasta_reader_summary_with_kind_and_hash;
 use biors_core::sequence::{KindAwareSequenceValidationSummary, SequenceKindCounts};
@@ -59,7 +59,7 @@ fn run_batch_validate(kind: KindArg, inputs: Vec<PathBuf>) -> Result<(), CliErro
 
     for file in dataset.files {
         let path = file.path;
-        let reader = open_fasta_input(&path)?;
+        let reader = open_buffered_input(&path)?;
         let validated = validate_fasta_reader_summary_with_kind_and_hash(reader, kind.into())
             .map_err(|error| CliError::from_fasta_read(path.clone(), error))?;
         output.summary.add_file(&validated.summary);

--- a/crates/biors/src/cli/handlers.rs
+++ b/crates/biors/src/cli/handlers.rs
@@ -9,7 +9,7 @@ use crate::cli::{
     run_template_command, run_workflow, PipelineRunOptions,
 };
 use crate::errors::CliError;
-use crate::input::{open_buffered_input, open_fasta_input, read_tokenizer_config};
+use crate::input::{open_buffered_input, read_tokenizer_config};
 use crate::output::print_success;
 use biors_core::{
     formats::{format_capabilities, validate_fastq_reader_with_hash},
@@ -239,7 +239,7 @@ fn run_molecule_inspect(format: MoleculeFormatArg, path: PathBuf) -> Result<(), 
 }
 
 fn run_inspect(path: PathBuf) -> Result<(), CliError> {
-    let reader = open_fasta_input(&path)?;
+    let reader = open_buffered_input(&path)?;
     let output = summarize_fasta_records_reader(reader)
         .map_err(|error| CliError::from_fasta_read(path, error))?;
     print_success(Some(output.input_hash), output.summary)
@@ -253,7 +253,7 @@ fn run_model_input(
     path: PathBuf,
 ) -> Result<(), CliError> {
     let config = protein_tokenizer_config_for_profile(profile.into());
-    let reader = open_fasta_input(&path)?;
+    let reader = open_buffered_input(&path)?;
     let output = tokenize_fasta_records_reader_with_config(reader, &config)
         .map_err(|error| CliError::from_fasta_read(path, error))?;
     let model_input = build_model_inputs_checked(
@@ -273,7 +273,7 @@ fn run_tokenize(
     path: PathBuf,
 ) -> Result<(), CliError> {
     let config = resolve_tokenizer_config(profile, config)?;
-    let reader = open_fasta_input(&path)?;
+    let reader = open_buffered_input(&path)?;
     let output = tokenize_fasta_records_reader_with_config(reader, &config)
         .map_err(|error| CliError::from_fasta_read(path, error))?;
     print_success(Some(output.input_hash), output.records)
@@ -304,7 +304,7 @@ fn resolve_tokenizer_config(
 }
 
 fn run_sequence_validation(path: PathBuf, kind: KindArg) -> Result<(), CliError> {
-    let reader = open_fasta_input(&path)?;
+    let reader = open_buffered_input(&path)?;
     let output = validate_fasta_reader_with_kind_and_hash(reader, kind.into())
         .map_err(|error| CliError::from_fasta_read(path, error))?;
     print_success(Some(output.input_hash), output.report)

--- a/crates/biors/src/cli/workflow.rs
+++ b/crates/biors/src/cli/workflow.rs
@@ -1,6 +1,6 @@
 use super::{PaddingArg, TokenizerProfileArg};
 use crate::errors::CliError;
-use crate::input::open_fasta_input;
+use crate::input::open_buffered_input;
 use crate::output::print_success;
 use biors_core::{
     fasta::parse_fasta_records_reader,
@@ -66,7 +66,7 @@ pub(crate) fn workflow_output_with_invocation_path(
         padding: padding.into(),
     };
     validate_model_input_policy(&policy)?;
-    let reader = open_fasta_input(&path)?;
+    let reader = open_buffered_input(&path)?;
     let input = parse_fasta_records_reader(reader)
         .map_err(|error| CliError::from_fasta_read(path.clone(), error))?;
     let invocation = workflow_invocation(

--- a/crates/biors/src/input.rs
+++ b/crates/biors/src/input.rs
@@ -12,10 +12,6 @@ pub(crate) use sources::{
     ResolvedInputFile,
 };
 
-pub(crate) fn open_fasta_input(path: &PathBuf) -> Result<Box<dyn BufRead>, CliError> {
-    open_buffered_input(path)
-}
-
 pub(crate) fn open_buffered_input(path: &PathBuf) -> Result<Box<dyn BufRead>, CliError> {
     if path.as_os_str() == "-" {
         return Ok(Box::new(BufReader::new(io::stdin())));

--- a/crates/biors/src/output.rs
+++ b/crates/biors/src/output.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use std::io::{self, Write};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+const ERROR_SERIALIZATION_FALLBACK: &str = r#"{"ok":false,"error":{"code":"cli.internal_error","message":"failed to serialize error","location":null}}"#;
 
 #[derive(Debug, Serialize)]
 struct CliSuccess<T: Serialize> {
@@ -55,38 +56,28 @@ fn write_success_to<W: Write, T: Serialize>(
 }
 
 pub(crate) fn print_json_error(error: CliError) {
-    let payload = CliFailure {
-        ok: false,
-        error: CliErrorBody {
-            code: error.code(),
-            message: error.to_string(),
-            location: error.location(),
-            details: error.details().cloned(),
-        },
-    };
-    match to_json(&payload) {
-        Ok(json) => println!("{json}"),
-        Err(_) => println!(
-            r#"{{"ok":false,"error":{{"code":"cli.internal_error","message":"failed to serialize error","location":null}}}}"#
-        ),
-    }
+    print_json_failure(CliErrorBody {
+        code: error.code(),
+        message: error.to_string(),
+        location: error.location(),
+        details: error.details().cloned(),
+    });
 }
 
 pub(crate) fn print_json_parse_error(error: &clap::Error) {
-    let payload = CliFailure {
-        ok: false,
-        error: CliErrorBody {
-            code: "cli.invalid_arguments",
-            message: error.to_string(),
-            location: None,
-            details: None,
-        },
-    };
+    print_json_failure(CliErrorBody {
+        code: "cli.invalid_arguments",
+        message: error.to_string(),
+        location: None,
+        details: None,
+    });
+}
+
+fn print_json_failure(error: CliErrorBody) {
+    let payload = CliFailure { ok: false, error };
     match to_json(&payload) {
         Ok(json) => println!("{json}"),
-        Err(_) => println!(
-            r#"{{"ok":false,"error":{{"code":"cli.internal_error","message":"failed to serialize error","location":null}}}}"#
-        ),
+        Err(_) => println!("{ERROR_SERIALIZATION_FALLBACK}"),
     }
 }
 
@@ -109,10 +100,7 @@ mod tests {
         );
 
         assert!(output.ends_with(b"\n"));
-        let value: Value = match serde_json::from_slice(&output) {
-            Ok(v) => v,
-            Err(e) => panic!("invalid JSON: {e}"),
-        };
+        let value: Value = serde_json::from_slice(&output).expect("success envelope JSON");
         assert_eq!(value["ok"], true);
         assert_eq!(value["biors_version"], env!("CARGO_PKG_VERSION"));
         assert_eq!(value["input_hash"], "fnv1a64:test");

--- a/crates/biors/tests/release_gate_policy.rs
+++ b/crates/biors/tests/release_gate_policy.rs
@@ -1,42 +1,39 @@
 use std::fs;
+use std::path::Path;
 
 mod common;
 
 #[test]
 fn final_release_checklist_covers_required_gates() {
     let repo = common::repo_root();
-    let script =
-        fs::read_to_string(repo.join("scripts/check-final-release.sh")).expect("read final script");
-    let full_check = fs::read_to_string(repo.join("scripts/check.sh")).expect("read full check");
-    let package_artifacts = fs::read_to_string(repo.join("scripts/check-package-artifacts.sh"))
-        .expect("read package artifact check");
+    let script = read_repo_file(&repo, "scripts/check-final-release.sh");
+    let full_check = read_repo_file(&repo, "scripts/check.sh");
+    let package_artifacts = read_repo_file(&repo, "scripts/check-package-artifacts.sh");
     let workflow_check = [
         "scripts/check-release-workflow.py",
         "scripts/release/workflow_jobs.py",
         "scripts/release/workflow_text_markers.py",
     ]
     .into_iter()
-    .map(|path| fs::read_to_string(repo.join(path)).expect("read release workflow check"))
+    .map(|path| read_repo_file(&repo, path))
     .collect::<Vec<_>>()
     .join("\n");
-    let release_workflow = fs::read_to_string(repo.join(".github/workflows/release.yml"))
-        .expect("read release workflow");
-    let attributes = fs::read_to_string(repo.join(".gitattributes")).expect("read attributes");
+    let release_workflow = read_repo_file(&repo, ".github/workflows/release.yml");
+    let attributes = read_repo_file(&repo, ".gitattributes");
 
-    for expected in [
-        "scripts/check.sh",
-        "scripts/check-security-audit.sh",
-        "cargo build --locked --release -p biors",
-        "BIORS_BIN=target/release/biors sh scripts/launch-demo.sh",
-        "scripts/check-install-smoke.sh",
-        "scripts/check-package-artifacts.sh",
-        "python3 scripts/check-release-workflow.py",
-    ] {
-        assert!(
-            script.contains(expected),
-            "final release script missing {expected}"
-        );
-    }
+    assert_contains_all(
+        &script,
+        &[
+            "scripts/check.sh",
+            "scripts/check-security-audit.sh",
+            "cargo build --locked --release -p biors",
+            "BIORS_BIN=target/release/biors sh scripts/launch-demo.sh",
+            "scripts/check-install-smoke.sh",
+            "scripts/check-package-artifacts.sh",
+            "python3 scripts/check-release-workflow.py",
+        ],
+        "final release script missing",
+    );
     assert!(
         full_check.contains("scripts/check-benchmark-docs.sh"),
         "full release check missing scripts/check-benchmark-docs.sh"
@@ -51,27 +48,25 @@ fn final_release_checklist_covers_required_gates() {
         "final release gate must transitively run the dependency policy check"
     );
 
-    for expected in ["id-token: write", "npm publish", "--provenance"] {
-        assert!(
-            release_workflow.contains(expected),
-            "release workflow missing trusted publishing invariant {expected}"
-        );
-    }
+    assert_contains_all(
+        &release_workflow,
+        &["id-token: write", "npm publish", "--provenance"],
+        "release workflow missing trusted publishing invariant",
+    );
 
-    for expected in [
-        "--provenance",
-        "npm publish",
-        "scripts/check-release-artifact-contents.py",
-        "scripts/check-registry-versions.py",
-        "scripts/print-release-tool-versions.sh",
-        "NPM_TOKEN",
-        "NODE_AUTH_TOKEN",
-    ] {
-        assert!(
-            workflow_check.contains(expected),
-            "release workflow check missing trusted publishing invariant {expected}"
-        );
-    }
+    assert_contains_all(
+        &workflow_check,
+        &[
+            "--provenance",
+            "npm publish",
+            "scripts/check-release-artifact-contents.py",
+            "scripts/check-registry-versions.py",
+            "scripts/print-release-tool-versions.sh",
+            "NPM_TOKEN",
+            "NODE_AUTH_TOKEN",
+        ],
+        "release workflow check missing trusted publishing invariant",
+    );
 
     assert!(
         attributes.contains("testdata/protein-package/** text eol=lf"),
@@ -109,56 +104,53 @@ fn repository_layout_uses_current_public_surface_names() {
 #[test]
 fn security_policy_covers_promoted_public_surfaces() {
     let repo = common::repo_root();
-    let security = fs::read_to_string(repo.join("SECURITY.md")).expect("read security policy");
+    let security = read_repo_file(&repo, "SECURITY.md");
 
-    for expected in [
-        "biors-core",
-        "biors-backend-candle",
-        "biors-mcp-server",
-        "biors-python",
-        "biors-wasm",
-        "package conversion",
-        "cache cleanup",
-        "MCP tool inputs",
-        "WASM/npm package APIs",
-        "external-process backend contracts",
-        "Candle model artifact loading",
-        "local filesystem safety",
-        "should not upload biological data",
-    ] {
-        assert!(
-            security.contains(expected),
-            "SECURITY.md missing promoted security surface detail: {expected}"
-        );
-    }
+    assert_contains_all(
+        &security,
+        &[
+            "biors-core",
+            "biors-backend-candle",
+            "biors-mcp-server",
+            "biors-python",
+            "biors-wasm",
+            "package conversion",
+            "cache cleanup",
+            "MCP tool inputs",
+            "WASM/npm package APIs",
+            "external-process backend contracts",
+            "Candle model artifact loading",
+            "local filesystem safety",
+            "should not upload biological data",
+        ],
+        "SECURITY.md missing promoted security surface detail:",
+    );
 }
 
 #[test]
 fn benchmark_workflow_runs_smoke_and_scheduled_criterion_suite() {
     let repo = common::repo_root();
-    let workflow = fs::read_to_string(repo.join(".github/workflows/benchmarks.yml"))
-        .expect("read benchmark workflow");
+    let workflow = read_repo_file(&repo, ".github/workflows/benchmarks.yml");
 
-    for expected in [
-        "pull_request:",
-        "workflow_dispatch:",
-        "schedule:",
-        "permissions:",
-        "contents: read",
-        "scripts/check-benchmark-docs.sh",
-        "cargo test --workspace --benches --all-features",
-        "if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'",
-        "cargo bench -p biors-core --bench fasta_workloads",
-        "cargo bench -p biors-core --bench package_validation",
-        "cargo bench -p biors-core --bench workflow_workloads",
-        "cargo bench -p biors-backend-candle --bench candle_linear_probe",
-        "cargo bench -p biors-mcp-server --bench mcp_request_overhead",
-    ] {
-        assert!(
-            workflow.contains(expected),
-            "benchmark workflow missing {expected}"
-        );
-    }
+    assert_contains_all(
+        &workflow,
+        &[
+            "pull_request:",
+            "workflow_dispatch:",
+            "schedule:",
+            "permissions:",
+            "contents: read",
+            "scripts/check-benchmark-docs.sh",
+            "cargo test --workspace --benches --all-features",
+            "if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'",
+            "cargo bench -p biors-core --bench fasta_workloads",
+            "cargo bench -p biors-core --bench package_validation",
+            "cargo bench -p biors-core --bench workflow_workloads",
+            "cargo bench -p biors-backend-candle --bench candle_linear_probe",
+            "cargo bench -p biors-mcp-server --bench mcp_request_overhead",
+        ],
+        "benchmark workflow missing",
+    );
 }
 
 #[test]
@@ -223,11 +215,9 @@ fn published_rust_crates_include_discovery_metadata() {
 #[test]
 fn local_check_scripts_use_rendered_benchmark_docs_gate() {
     let repo = common::repo_root();
-    let check = fs::read_to_string(repo.join("scripts/check.sh")).expect("read check.sh");
-    let check_fast =
-        fs::read_to_string(repo.join("scripts/check-fast.sh")).expect("read check-fast.sh");
-    let benchmark_gate = fs::read_to_string(repo.join("scripts/check-benchmark-docs.sh"))
-        .expect("read benchmark docs gate");
+    let check = read_repo_file(&repo, "scripts/check.sh");
+    let check_fast = read_repo_file(&repo, "scripts/check-fast.sh");
+    let benchmark_gate = read_repo_file(&repo, "scripts/check-benchmark-docs.sh");
 
     for (name, script) in [("check.sh", check), ("check-fast.sh", check_fast)] {
         assert!(
@@ -253,4 +243,14 @@ fn local_check_scripts_use_rendered_benchmark_docs_gate() {
         !benchmark_gate.contains("fasta_vs_biopython"),
         "benchmark docs gate must not depend on removed historical FASTA benchmark artifacts"
     );
+}
+
+fn read_repo_file(repo: &Path, path: &str) -> String {
+    fs::read_to_string(repo.join(path)).unwrap_or_else(|_| panic!("read {path}"))
+}
+
+fn assert_contains_all(haystack: &str, expected: &[&str], failure_prefix: &str) {
+    for expected in expected {
+        assert!(haystack.contains(expected), "{failure_prefix} {expected}");
+    }
 }

--- a/schemas/AGENTS.md
+++ b/schemas/AGENTS.md
@@ -1,0 +1,50 @@
+# SCHEMAS KNOWLEDGE BASE
+
+## OVERVIEW
+
+`schemas/` contains public JSON Schema contracts for CLI output, service
+requests/responses, package manifests, reports, pipeline files, browser/WASM
+outputs, and validation diagnostics.
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| CLI output schema | `*-output.v0.json`, `cli-*.v0.json` | Must match command tests and docs |
+| Package manifests | `package-manifest.v0.json`, `package-manifest.v1.json` | Versioned public package contract |
+| Service contracts | `service-*.v0.json` | Local service request/response shape |
+| Pipeline contracts | `pipeline-*.v0.json` | Pipeline config, lock, output |
+| Validation diagnostics | `*-validation-output.v0.json`, `cli-error.v0.json` | Stable issue/error fields |
+
+## CONVENTIONS
+
+- Schema files are public contracts, not loose examples.
+- Preserve explicit schema identifiers and version tags. Unknown schema versions
+  must remain rejectable by readers with stable validation errors.
+- Change schema, implementation, tests, docs, and fixtures in the same slice.
+- Prefer additive fields for patch/minor evolution. Tightening required fields,
+  removing enum values, or changing field types is a breaking contract change
+  unless compatibility handling is implemented.
+- Keep package schemas strict about package-relative paths, declared layout
+  directories, checksums, and required research metadata.
+- Use schema names that match the command/service/report surface; avoid
+  placeholder or roadmap schemas.
+
+## CHECKS
+
+```bash
+cargo test -p biors --test schema_contract
+cargo test -p biors --test schema_cli_package_contract
+cargo test -p biors-core --test schema_versioning
+scripts/check-fast.sh
+```
+
+Add focused schema tests for new surfaces before expanding broad release gates.
+
+## ANTI-PATTERNS
+
+- Keeping unused schemas "just in case".
+- Marking future product surfaces as supported before code and tests produce
+  matching payloads.
+- Weakening validation to make a fixture pass without preserving researcher-use
+  error quality.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,64 @@
+# SCRIPTS KNOWLEDGE BASE
+
+## OVERVIEW
+
+`scripts/` is executable repository policy: local gates, release preflights,
+benchmark report generation, package checks, and maintenance helpers.
+
+## STRUCTURE
+
+```text
+scripts/
+|-- check*.sh / check*.py       # local, CI, release, dependency gates
+|-- release/                    # release workflow invariant helpers
+|-- benchmarks/                 # benchmark runners, artifact checks, renderers
+|-- *release* / *registry*      # version, registry, checksum, status tooling
+`-- build-wasm-npm-package.sh   # WASM/npm package build path
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Fast local gate | `check-fast.sh` | Iteration and pre-commit subset |
+| Full gate | `check.sh` | CI-equivalent local check |
+| Final release preflight | `check-final-release.sh` | Strongest local release gate |
+| Workflow invariants | `check-release-workflow.py`, `release/` | Pinning, job order, release markers |
+| Package artifacts | `check-package-artifacts.sh`, `check-release-artifact-contents.py` | Python, npm, crate, binary contents |
+| Registry versions | `check-registry-versions.py` | Tag-release publish preflight |
+| Benchmarks | `benchmarks/`, `check-benchmark-docs.sh` | Reports must match JSON artifacts |
+
+## CONVENTIONS
+
+- Match the existing shebang. Most shell gates are `#!/bin/sh`; keep them
+  portable. Bash-specific scripts must declare Bash and justify it by existing
+  behavior.
+- Python scripts should be deterministic CLI tools with clear nonzero failures;
+  avoid hidden network calls except explicit registry/status checks.
+- Release tool versions are pinned in `release-tool-versions.env`; workflow and
+  script pins must stay aligned.
+- GitHub Actions references are pinned by policy; update pin checks with
+  workflow changes.
+- Benchmark scripts update both JSON artifacts and rendered Markdown. Keep
+  `check-benchmark-docs.sh` synchronized with every committed benchmark report.
+- Registry/version scripts must distinguish local dry-run checks from tag-time
+  publish checks.
+
+## CHECKS
+
+```bash
+scripts/check-fast.sh
+scripts/check.sh
+python3 scripts/check-release-workflow.py
+scripts/check-final-release.sh
+```
+
+Run only the focused script while editing, then the containing gate before
+shipping release- or CI-affecting changes.
+
+## ANTI-PATTERNS
+
+- Bypassing script gates by duplicating command lists in docs or workflows.
+- Leaving generated wheels, npm packages, binary archives, local caches, or
+  temporary release output in the repository.
+- Making broad benchmark or release-readiness claims from stale artifacts.

--- a/scripts/benchmarks/artifact_validation.py
+++ b/scripts/benchmarks/artifact_validation.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
-JsonScalar: TypeAlias = str | int | float | bool | None
-JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
 JsonObject: TypeAlias = dict[str, JsonValue]
 
 
@@ -14,7 +13,7 @@ def load_json_object(path: Path) -> JsonObject:
     result = json.loads(path.read_text())
     if not isinstance(result, dict):
         raise AssertionError("benchmark artifact must be a JSON object")
-    return cast(JsonObject, result)
+    return result
 
 
 def validate_schema_version(result: JsonObject, expected: str, message: str) -> None:

--- a/scripts/benchmarks/artifact_validation.py
+++ b/scripts/benchmarks/artifact_validation.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 from pathlib import Path
+from typing import TypeAlias, cast
 
-JsonObject = dict[str, object]
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
 
 
 def load_json_object(path: Path) -> JsonObject:
     result = json.loads(path.read_text())
     if not isinstance(result, dict):
         raise AssertionError("benchmark artifact must be a JSON object")
-    return result
+    return cast(JsonObject, result)
 
 
 def validate_schema_version(result: JsonObject, expected: str, message: str) -> None:
@@ -25,13 +28,13 @@ def require_top_level_fields(result: JsonObject, fields: Iterable[str]) -> None:
             raise AssertionError(f"missing top-level field: {field}")
 
 
-def require_object(value: object, message: str) -> JsonObject:
+def require_object(value: JsonValue, message: str) -> JsonObject:
     if not isinstance(value, dict):
         raise AssertionError(message)
     return value
 
 
-def require_fields(value: object, fields: Iterable[str], label: str) -> JsonObject:
+def require_fields(value: JsonValue, fields: Iterable[str], label: str) -> JsonObject:
     result = require_object(value, f"{label} must be an object")
     for field in fields:
         if field not in result:
@@ -39,18 +42,18 @@ def require_fields(value: object, fields: Iterable[str], label: str) -> JsonObje
     return result
 
 
-def require_sha256(value: object, message: str) -> None:
+def require_sha256(value: JsonValue, message: str) -> None:
     if not str(value).startswith("sha256:"):
         raise AssertionError(message)
 
 
-def require_timed_iterations(value: object, message: str) -> None:
+def require_timed_iterations(value: JsonValue, message: str) -> None:
     if not value:
         raise AssertionError(message)
 
 
 def validate_criterion_estimate(
-    estimate: object,
+    estimate: JsonValue,
     name: str,
     *,
     require_confidence_interval_fields: bool,

--- a/scripts/benchmarks/artifact_validation.py
+++ b/scripts/benchmarks/artifact_validation.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+JsonObject = dict[str, object]
+
+
+def load_json_object(path: Path) -> JsonObject:
+    result = json.loads(path.read_text())
+    if not isinstance(result, dict):
+        raise AssertionError("benchmark artifact must be a JSON object")
+    return result
+
+
+def validate_schema_version(result: JsonObject, expected: str, message: str) -> None:
+    if result.get("schema_version") != expected:
+        raise AssertionError(message)
+
+
+def require_top_level_fields(result: JsonObject, fields: Iterable[str]) -> None:
+    for field in fields:
+        if field not in result:
+            raise AssertionError(f"missing top-level field: {field}")
+
+
+def require_object(value: object, message: str) -> JsonObject:
+    if not isinstance(value, dict):
+        raise AssertionError(message)
+    return value
+
+
+def require_fields(value: object, fields: Iterable[str], label: str) -> JsonObject:
+    result = require_object(value, f"{label} must be an object")
+    for field in fields:
+        if field not in result:
+            raise AssertionError(f"{label} missing {field}")
+    return result
+
+
+def require_sha256(value: object, message: str) -> None:
+    if not str(value).startswith("sha256:"):
+        raise AssertionError(message)
+
+
+def require_timed_iterations(value: object, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+def validate_criterion_estimate(
+    estimate: object,
+    name: str,
+    *,
+    require_confidence_interval_fields: bool,
+) -> None:
+    estimate = require_fields(
+        estimate,
+        ["point_estimate", "confidence_interval", "standard_error"],
+        f"{name} estimate",
+    )
+    if require_confidence_interval_fields:
+        require_fields(
+            estimate["confidence_interval"],
+            ["confidence_level", "lower_bound", "upper_bound"],
+            f"{name} confidence interval",
+        )

--- a/scripts/benchmarks/check-backend-benchmark-artifact.py
+++ b/scripts/benchmarks/check-backend-benchmark-artifact.py
@@ -3,21 +3,30 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
+from artifact_validation import (
+    load_json_object,
+    require_top_level_fields,
+    validate_criterion_estimate,
+    validate_schema_version,
+)
 from benchmark_release_status import validate_release_status
 
 RESULT_PATH = Path("benchmarks/backend_smoke.json")
 
 
 def main() -> int:
-    result = json.loads(RESULT_PATH.read_text())
-    if result.get("schema_version") != "biors.benchmark.backend_smoke.v1":
-        raise AssertionError("backend smoke benchmark artifact must use schema v1")
-    for field in ["generated_at_utc", "methodology", "environment", "workloads"]:
-        if field not in result:
-            raise AssertionError(f"missing top-level field: {field}")
+    result = load_json_object(RESULT_PATH)
+    validate_schema_version(
+        result,
+        "biors.benchmark.backend_smoke.v1",
+        "backend smoke benchmark artifact must use schema v1",
+    )
+    require_top_level_fields(
+        result,
+        ["generated_at_utc", "methodology", "environment", "workloads"],
+    )
     validate_release_status(
         result,
         environment_key="biors_backend_candle",
@@ -32,20 +41,12 @@ def main() -> int:
     if not isinstance(estimates, dict):
         raise AssertionError("backend smoke workload must include Criterion estimates")
     for estimate in ["mean", "median", "slope"]:
-        validate_estimate(estimates.get(estimate), estimate)
+        validate_criterion_estimate(
+            estimates.get(estimate),
+            estimate,
+            require_confidence_interval_fields=True,
+        )
     return 0
-
-
-def validate_estimate(estimate: object, name: str) -> None:
-    if not isinstance(estimate, dict):
-        raise AssertionError(f"{name} estimate must be an object")
-    for field in ["point_estimate", "confidence_interval", "standard_error"]:
-        if field not in estimate:
-            raise AssertionError(f"{name} estimate missing {field}")
-    interval = estimate["confidence_interval"]
-    for field in ["confidence_level", "lower_bound", "upper_bound"]:
-        if field not in interval:
-            raise AssertionError(f"{name} confidence interval missing {field}")
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/check-cli-benchmark-artifact.py
+++ b/scripts/benchmarks/check-cli-benchmark-artifact.py
@@ -3,9 +3,17 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
+from artifact_validation import (
+    load_json_object,
+    require_fields,
+    require_object,
+    require_sha256,
+    require_timed_iterations,
+    require_top_level_fields,
+    validate_schema_version,
+)
 from benchmark_release_status import validate_release_status
 
 RESULT_PATH = Path("benchmarks/cli_surfaces.json")
@@ -27,12 +35,16 @@ REQUIRED_WORKLOADS = {
 
 
 def main() -> int:
-    result = json.loads(RESULT_PATH.read_text())
-    if result.get("schema_version") != "biors.benchmark.cli_surfaces.v1":
-        raise AssertionError("CLI benchmark artifact must use schema v1")
-    for field in ["generated_at_utc", "loops", "methodology", "environment", "workloads"]:
-        if field not in result:
-            raise AssertionError(f"missing top-level field: {field}")
+    result = load_json_object(RESULT_PATH)
+    validate_schema_version(
+        result,
+        "biors.benchmark.cli_surfaces.v1",
+        "CLI benchmark artifact must use schema v1",
+    )
+    require_top_level_fields(
+        result,
+        ["generated_at_utc", "loops", "methodology", "environment", "workloads"],
+    )
     validate_release_status(result, environment_key="biors", package_name="biors")
     workloads = {workload["name"]: workload for workload in result["workloads"]}
     missing = sorted(set(REQUIRED_WORKLOADS) - set(workloads))
@@ -48,12 +60,12 @@ def main() -> int:
 
 
 def validate_input(input_: object) -> None:
-    if not isinstance(input_, dict):
-        raise AssertionError("workload input must be an object")
+    input_ = require_object(input_, "workload input must be an object")
     if input_.get("kind") == "no_input":
         return
-    if "sha256" not in input_ or not str(input_["sha256"]).startswith("sha256:"):
+    if "sha256" not in input_:
         raise AssertionError("workload input sha256 must use sha256:<hex>")
+    require_sha256(input_["sha256"], "workload input sha256 must use sha256:<hex>")
     if "file_size_bytes" not in input_:
         raise AssertionError("workload input missing file_size_bytes")
     if "records" in input_ and "total_residues" not in input_:
@@ -61,19 +73,18 @@ def validate_input(input_: object) -> None:
 
 
 def validate_result(result: object) -> None:
-    if not isinstance(result, dict):
-        raise AssertionError("workload result must be an object")
-    for field in ["command", "output_hash", "seconds", "summary"]:
-        if field not in result:
-            raise AssertionError(f"workload result missing {field}")
-    if not str(result["output_hash"]).startswith("sha256:"):
-        raise AssertionError("workload output hash must use sha256:<hex>")
-    if not result["seconds"]:
-        raise AssertionError("workload must include timed iterations")
-    summary = result["summary"]
-    for field in ["mean_s", "median_s", "min_s", "max_s", "stdout_bytes"]:
-        if field not in summary:
-            raise AssertionError(f"workload summary missing {field}")
+    result = require_fields(
+        result,
+        ["command", "output_hash", "seconds", "summary"],
+        "workload result",
+    )
+    require_sha256(result["output_hash"], "workload output hash must use sha256:<hex>")
+    require_timed_iterations(result["seconds"], "workload must include timed iterations")
+    require_fields(
+        result["summary"],
+        ["mean_s", "median_s", "min_s", "max_s", "stdout_bytes"],
+        "workload summary",
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/check-cli-benchmark-artifact.py
+++ b/scripts/benchmarks/check-cli-benchmark-artifact.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from artifact_validation import (
+    JsonValue,
     load_json_object,
     require_fields,
     require_object,
@@ -59,7 +60,7 @@ def main() -> int:
     return 0
 
 
-def validate_input(input_: object) -> None:
+def validate_input(input_: JsonValue) -> None:
     input_ = require_object(input_, "workload input must be an object")
     if input_.get("kind") == "no_input":
         return
@@ -72,7 +73,7 @@ def validate_input(input_: object) -> None:
         raise AssertionError("FASTA workload input missing total_residues")
 
 
-def validate_result(result: object) -> None:
+def validate_result(result: JsonValue) -> None:
     result = require_fields(
         result,
         ["command", "output_hash", "seconds", "summary"],

--- a/scripts/benchmarks/check-mcp-benchmark-artifact.py
+++ b/scripts/benchmarks/check-mcp-benchmark-artifact.py
@@ -3,21 +3,30 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
+from artifact_validation import (
+    load_json_object,
+    require_top_level_fields,
+    validate_criterion_estimate,
+    validate_schema_version,
+)
 from benchmark_release_status import validate_release_status
 
 RESULT_PATH = Path("benchmarks/mcp_server.json")
 
 
 def main() -> int:
-    result = json.loads(RESULT_PATH.read_text())
-    if result.get("schema_version") != "biors.benchmark.mcp_server.v1":
-        raise AssertionError("MCP benchmark artifact must use schema v1")
-    for field in ["generated_at_utc", "methodology", "environment", "workloads"]:
-        if field not in result:
-            raise AssertionError(f"missing top-level field: {field}")
+    result = load_json_object(RESULT_PATH)
+    validate_schema_version(
+        result,
+        "biors.benchmark.mcp_server.v1",
+        "MCP benchmark artifact must use schema v1",
+    )
+    require_top_level_fields(
+        result,
+        ["generated_at_utc", "methodology", "environment", "workloads"],
+    )
     validate_release_status(
         result,
         environment_key="biors_mcp_server",
@@ -32,16 +41,12 @@ def main() -> int:
     if not isinstance(estimates, dict):
         raise AssertionError("MCP workload must include Criterion estimates")
     for estimate in ["mean", "median", "slope"]:
-        validate_estimate(estimates.get(estimate), estimate)
+        validate_criterion_estimate(
+            estimates.get(estimate),
+            estimate,
+            require_confidence_interval_fields=False,
+        )
     return 0
-
-
-def validate_estimate(estimate: object, name: str) -> None:
-    if not isinstance(estimate, dict):
-        raise AssertionError(f"{name} estimate must be an object")
-    for field in ["point_estimate", "confidence_interval", "standard_error"]:
-        if field not in estimate:
-            raise AssertionError(f"{name} estimate missing {field}")
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/check-python-benchmark-artifact.py
+++ b/scripts/benchmarks/check-python-benchmark-artifact.py
@@ -3,9 +3,16 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
+from artifact_validation import (
+    load_json_object,
+    require_fields,
+    require_sha256,
+    require_timed_iterations,
+    require_top_level_fields,
+    validate_schema_version,
+)
 from benchmark_release_status import validate_release_status
 
 RESULT_PATH = Path("benchmarks/python_bindings.json")
@@ -24,12 +31,16 @@ REQUIRED_WORKLOADS = {
 
 
 def main() -> int:
-    result = json.loads(RESULT_PATH.read_text())
-    if result.get("schema_version") != "biors.benchmark.python_bindings.v1":
-        raise AssertionError("Python benchmark artifact must use schema v1")
-    for field in ["generated_at_utc", "loops", "methodology", "environment", "input", "workloads"]:
-        if field not in result:
-            raise AssertionError(f"missing top-level field: {field}")
+    result = load_json_object(RESULT_PATH)
+    validate_schema_version(
+        result,
+        "biors.benchmark.python_bindings.v1",
+        "Python benchmark artifact must use schema v1",
+    )
+    require_top_level_fields(
+        result,
+        ["generated_at_utc", "loops", "methodology", "environment", "input", "workloads"],
+    )
     validate_release_status(
         result,
         environment_key="biors_python",
@@ -46,26 +57,27 @@ def main() -> int:
 
 
 def validate_input(input_: object) -> None:
-    if not isinstance(input_, dict):
-        raise AssertionError("input must be an object")
-    for field in ["records", "record_length", "total_residues", "fasta_bytes", "sha256"]:
-        if field not in input_:
-            raise AssertionError(f"input missing {field}")
-    if not str(input_["sha256"]).startswith("sha256:"):
-        raise AssertionError("input sha256 must use sha256:<hex>")
+    input_ = require_fields(
+        input_,
+        ["records", "record_length", "total_residues", "fasta_bytes", "sha256"],
+        "input",
+    )
+    require_sha256(input_["sha256"], "input sha256 must use sha256:<hex>")
 
 
 def validate_workload(workload: dict) -> None:
-    for field in ["name", "output_hash", "warmup_summary", "seconds", "summary"]:
-        if field not in workload:
-            raise AssertionError(f"workload missing {field}")
-    if not str(workload["output_hash"]).startswith("sha256:"):
-        raise AssertionError("workload output hash must use sha256:<hex>")
-    if not workload["seconds"]:
-        raise AssertionError("workload must include timed iterations")
-    for field in ["mean_s", "median_s", "min_s", "max_s"]:
-        if field not in workload["summary"]:
-            raise AssertionError(f"workload summary missing {field}")
+    require_fields(
+        workload,
+        ["name", "output_hash", "warmup_summary", "seconds", "summary"],
+        "workload",
+    )
+    require_sha256(workload["output_hash"], "workload output hash must use sha256:<hex>")
+    require_timed_iterations(workload["seconds"], "workload must include timed iterations")
+    require_fields(
+        workload["summary"],
+        ["mean_s", "median_s", "min_s", "max_s"],
+        "workload summary",
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/check-python-benchmark-artifact.py
+++ b/scripts/benchmarks/check-python-benchmark-artifact.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from artifact_validation import (
+    JsonObject,
+    JsonValue,
     load_json_object,
     require_fields,
     require_sha256,
@@ -56,7 +58,7 @@ def main() -> int:
     return 0
 
 
-def validate_input(input_: object) -> None:
+def validate_input(input_: JsonValue) -> None:
     input_ = require_fields(
         input_,
         ["records", "record_length", "total_residues", "fasta_bytes", "sha256"],
@@ -65,7 +67,7 @@ def validate_input(input_: object) -> None:
     require_sha256(input_["sha256"], "input sha256 must use sha256:<hex>")
 
 
-def validate_workload(workload: dict) -> None:
+def validate_workload(workload: JsonObject) -> None:
     require_fields(
         workload,
         ["name", "output_hash", "warmup_summary", "seconds", "summary"],

--- a/scripts/benchmarks/check-wasm-benchmark-artifact.py
+++ b/scripts/benchmarks/check-wasm-benchmark-artifact.py
@@ -3,9 +3,15 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
+from artifact_validation import (
+    load_json_object,
+    require_fields,
+    require_sha256,
+    require_top_level_fields,
+    validate_schema_version,
+)
 from benchmark_release_status import validate_release_status
 
 RESULT_PATH = Path("benchmarks/wasm_bindings.json")
@@ -22,12 +28,16 @@ REQUIRED_WORKLOADS = {
 
 
 def main() -> int:
-    result = json.loads(RESULT_PATH.read_text())
-    if result.get("schema_version") != "biors.benchmark.wasm_bindings.v1":
-        raise AssertionError("WASM benchmark artifact must use schema v1")
-    for field in ["generated_at_utc", "loops", "methodology", "environment", "workloads"]:
-        if field not in result:
-            raise AssertionError(f"missing top-level field: {field}")
+    result = load_json_object(RESULT_PATH)
+    validate_schema_version(
+        result,
+        "biors.benchmark.wasm_bindings.v1",
+        "WASM benchmark artifact must use schema v1",
+    )
+    require_top_level_fields(
+        result,
+        ["generated_at_utc", "loops", "methodology", "environment", "workloads"],
+    )
     validate_release_status(result, environment_key="biors_wasm", package_name="biors-wasm")
     workloads = {workload["name"]: workload for workload in result["workloads"]}
     missing = sorted(set(REQUIRED_WORKLOADS) - set(workloads))
@@ -43,23 +53,21 @@ def main() -> int:
 
 
 def validate_input(input_: object) -> None:
-    if not isinstance(input_, dict):
-        raise AssertionError("workload input must be an object")
-    for field in ["records", "total_residues", "file_size_bytes", "sha256"]:
-        if field not in input_:
-            raise AssertionError(f"workload input missing {field}")
-    if not str(input_["sha256"]).startswith("sha256:"):
-        raise AssertionError("workload input sha256 must use sha256:<hex>")
+    input_ = require_fields(
+        input_,
+        ["records", "total_residues", "file_size_bytes", "sha256"],
+        "workload input",
+    )
+    require_sha256(input_["sha256"], "workload input sha256 must use sha256:<hex>")
 
 
 def validate_summary(summary: object) -> None:
-    if not isinstance(summary, dict):
-        raise AssertionError("workload summary must be an object")
-    for field in ["mean_s", "median_s", "min_s", "max_s", "output_hash", "output_bytes"]:
-        if field not in summary:
-            raise AssertionError(f"workload summary missing {field}")
-    if not str(summary["output_hash"]).startswith("sha256:"):
-        raise AssertionError("workload output hash must use sha256:<hex>")
+    summary = require_fields(
+        summary,
+        ["mean_s", "median_s", "min_s", "max_s", "output_hash", "output_bytes"],
+        "workload summary",
+    )
+    require_sha256(summary["output_hash"], "workload output hash must use sha256:<hex>")
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/check-wasm-benchmark-artifact.py
+++ b/scripts/benchmarks/check-wasm-benchmark-artifact.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from artifact_validation import (
+    JsonValue,
     load_json_object,
     require_fields,
     require_sha256,
@@ -52,7 +53,7 @@ def main() -> int:
     return 0
 
 
-def validate_input(input_: object) -> None:
+def validate_input(input_: JsonValue) -> None:
     input_ = require_fields(
         input_,
         ["records", "total_residues", "file_size_bytes", "sha256"],
@@ -61,7 +62,7 @@ def validate_input(input_: object) -> None:
     require_sha256(input_["sha256"], "workload input sha256 must use sha256:<hex>")
 
 
-def validate_summary(summary: object) -> None:
+def validate_summary(summary: JsonValue) -> None:
     summary = require_fields(
         summary,
         ["mean_s", "median_s", "min_s", "max_s", "output_hash", "output_bytes"],

--- a/scripts/check-benchmark-docs.sh
+++ b/scripts/check-benchmark-docs.sh
@@ -15,13 +15,30 @@ check_rendered_report() {
   diff -u "$expected" "$tmp_file"
 }
 
-python3 scripts/benchmarks/check-cli-benchmark-artifact.py
-python3 scripts/benchmarks/check-python-benchmark-artifact.py
-python3 scripts/benchmarks/check-wasm-benchmark-artifact.py
-python3 scripts/benchmarks/check-backend-benchmark-artifact.py
-python3 scripts/benchmarks/check-mcp-benchmark-artifact.py
-check_rendered_report scripts/benchmarks/render_cli_benchmark_report.py benchmarks/cli_surfaces.md
-check_rendered_report scripts/benchmarks/render_python_benchmark_report.py benchmarks/python_bindings.md
-check_rendered_report scripts/benchmarks/render_wasm_benchmark_report.py benchmarks/wasm_bindings.md
-check_rendered_report scripts/benchmarks/render_backend_benchmark_report.py benchmarks/backend_smoke.md
-check_rendered_report scripts/benchmarks/render_mcp_benchmark_report.py benchmarks/mcp_server.md
+run_artifact_checks() {
+  for checker in \
+    scripts/benchmarks/check-cli-benchmark-artifact.py \
+    scripts/benchmarks/check-python-benchmark-artifact.py \
+    scripts/benchmarks/check-wasm-benchmark-artifact.py \
+    scripts/benchmarks/check-backend-benchmark-artifact.py \
+    scripts/benchmarks/check-mcp-benchmark-artifact.py
+  do
+    python3 "$checker"
+  done
+}
+
+check_rendered_reports() {
+  while read -r renderer expected
+  do
+    check_rendered_report "$renderer" "$expected"
+  done <<'REPORTS'
+scripts/benchmarks/render_cli_benchmark_report.py benchmarks/cli_surfaces.md
+scripts/benchmarks/render_python_benchmark_report.py benchmarks/python_bindings.md
+scripts/benchmarks/render_wasm_benchmark_report.py benchmarks/wasm_bindings.md
+scripts/benchmarks/render_backend_benchmark_report.py benchmarks/backend_smoke.md
+scripts/benchmarks/render_mcp_benchmark_report.py benchmarks/mcp_server.md
+REPORTS
+}
+
+run_artifact_checks
+check_rendered_reports

--- a/scripts/check-benchmark-docs.sh
+++ b/scripts/check-benchmark-docs.sh
@@ -7,38 +7,24 @@ cd "$repo_root"
 tmp_file="$(mktemp)"
 trap 'rm -f "$tmp_file"' EXIT
 
-check_rendered_report() {
-  renderer="$1"
-  expected="$2"
+for checker in \
+  scripts/benchmarks/check-cli-benchmark-artifact.py \
+  scripts/benchmarks/check-python-benchmark-artifact.py \
+  scripts/benchmarks/check-wasm-benchmark-artifact.py \
+  scripts/benchmarks/check-backend-benchmark-artifact.py \
+  scripts/benchmarks/check-mcp-benchmark-artifact.py
+do
+  python3 "$checker"
+done
 
+while read -r renderer expected
+do
   python3 "$renderer" >"$tmp_file"
   diff -u "$expected" "$tmp_file"
-}
-
-run_artifact_checks() {
-  for checker in \
-    scripts/benchmarks/check-cli-benchmark-artifact.py \
-    scripts/benchmarks/check-python-benchmark-artifact.py \
-    scripts/benchmarks/check-wasm-benchmark-artifact.py \
-    scripts/benchmarks/check-backend-benchmark-artifact.py \
-    scripts/benchmarks/check-mcp-benchmark-artifact.py
-  do
-    python3 "$checker"
-  done
-}
-
-check_rendered_reports() {
-  while read -r renderer expected
-  do
-    check_rendered_report "$renderer" "$expected"
-  done <<'REPORTS'
+done <<'REPORTS'
 scripts/benchmarks/render_cli_benchmark_report.py benchmarks/cli_surfaces.md
 scripts/benchmarks/render_python_benchmark_report.py benchmarks/python_bindings.md
 scripts/benchmarks/render_wasm_benchmark_report.py benchmarks/wasm_bindings.md
 scripts/benchmarks/render_backend_benchmark_report.py benchmarks/backend_smoke.md
 scripts/benchmarks/render_mcp_benchmark_report.py benchmarks/mcp_server.md
 REPORTS
-}
-
-run_artifact_checks
-check_rendered_reports


### PR DESCRIPTION
## Summary
- Add hierarchical agent guidance and tighten project cleanup boundaries.
- Simplify benchmark/release helper code and table-drive repeated assertions.
- Split workflow helper responsibilities and remove safe cleanup slop in CLI, MCP profile handling, and benchmark validation helpers.
- Preserve public CLI/MCP/schema behavior while reducing net LOC in the final cleanup commit.

## Verification
- `scripts/check.sh`
- `scripts/check-fast.sh`
- `scripts/check-security-audit.sh` (advisories/bans/licenses/sources OK; duplicate dependency warnings are existing lockfile structure)
- Targeted CLI and MCP tests for changed surfaces
- AST checks: no `unwrap()` remains in `crates/biors-mcp-server/src`; no Python `cast(...)` remains under `scripts`/`crates`
- Manual shell e2e: `fasta validate`, stdin `tokenize`, `workflow`, and JSON error path

## Risk
- Low behavior risk: changes are internal refactors and cleanup only.
- No public API, schema, version, dependency, or release metadata changes.
